### PR TITLE
Fixes issue #3

### DIFF
--- a/Velocity/GPD/GameGPD.cpp
+++ b/Velocity/GPD/GameGPD.cpp
@@ -14,6 +14,7 @@ GameGPD::GameGPD(FileIO *io) : GPDBase(io)
 void GameGPD::CleanGPD()
 {
 	xdbf->Clean();
+    io = xdbf->io;
 }
 
 AchievementEntry GameGPD::readAchievementEntry(XDBFEntry entry)

--- a/Velocity/GPD/XDBF.h
+++ b/Velocity/GPD/XDBF.h
@@ -52,9 +52,9 @@ public:
 
     // Description: re-write an entry
     void RewriteEntry(XDBFEntry entry, BYTE *entryBuffer);
+    FileIO *io;
 
 private:
-    FileIO *io;
     bool ioPassedIn;
     XDBFHeader header;
     vector<XDBFFreeMemEntry> freeMemory;


### PR DESCRIPTION
#### The Issue

Issue #3 was caused by the freeing of the `io` pointer in the `GameGPD` class. On [line 116](https://github.com/landr0id/Velocity/blob/master/Velocity/gpduploader.cpp#L116) of `gpduploader.cpp`, the `GameGPD::CleanGPD` method is called, which calls the `XDBF::Clean` method. In this method, the `io` pointer is freed, then is set to a newly allocated `FileIO` instance.

When the `io` is set, it doesn't set the `io` instance in the class which called the `Clean` method (`GameGPD`), resulting in `GameGPD` referencing `io` referencing a bad memory address.
#### The Solution

By making `XDBF`'s `io` public, we can then [reset](https://github.com/landr0id/Velocity/blob/6bde8e65c0c4a47889ed933a489de0785d27a2bf/Velocity/GPD/GameGPD.cpp#L17) the `GameGPD` `io` after calling `XDBF::Clean`.
