### PR TITLE
VC++ 2012: Fixed compile errors, added solution/project file

### DIFF
--- a/XboxInternals/Cryptography/XeKeys.cpp
+++ b/XboxInternals/Cryptography/XeKeys.cpp
@@ -9,25 +9,25 @@ bool XeKeys::VerifyRSASignature(XeKeysRsaKeys key, BYTE *pbMessage, DWORD cbMess
     switch (key)
     {
         case PIRSKey:
-            modulus1 = PirsModulus1;
+            modulus1 = const_cast<BYTE*>(PirsModulus1);
             modulus2 = NULL;
             exponent1 = 3;
             exponent2 = 0;
             break;
         case LIVEKey:
-            modulus1 = LiveModulus1;
-            modulus2 = LiveDeviceModulus;
+            modulus1 = const_cast<BYTE*>(LiveModulus1);
+            modulus2 = const_cast<BYTE*>(LiveDeviceModulus);
             exponent1 = 0x10001;
             exponent2 = 3;
             break;
         case DeviceKey:
-            modulus1 = DeviceModulus1;
-            modulus2 = LiveDeviceModulus;
+            modulus1 = const_cast<BYTE*>(DeviceModulus1);
+            modulus2 = const_cast<BYTE*>(LiveDeviceModulus);
             exponent1 = exponent2 = 3;
             break;
         case UnknownKey:
-            modulus1 = UnknownModulus1;
-            modulus2 = UnknownModulus2;
+            modulus1 = const_cast<BYTE*>(UnknownModulus1);
+            modulus2 = const_cast<BYTE*>(UnknownModulus2);
             exponent1 = exponent2 = 3;
             break;
         default:

--- a/XboxInternals/FATX/FatxDrive.h
+++ b/XboxInternals/FATX/FatxDrive.h
@@ -20,7 +20,7 @@ class XBOXINTERNALSSHARED_EXPORT FatxDrive
 {
 public:
     FatxDrive(BaseIO *io, FatxDriveType type);
-    FatxDrive(HANDLE deviceHandle, FatxDriveType type = FatxHarddrive);
+    FatxDrive(void* deviceHandle, FatxDriveType type = FatxHarddrive);
     FatxDrive(std::string drivePath, FatxDriveType type = FatxHarddrive);
     FatxDrive(std::wstring drivePath, FatxDriveType type = FatxHarddrive);
     ~FatxDrive();
@@ -99,7 +99,7 @@ private:
     void loadFatxDrive(std::wstring drivePath);
 
     // open up a physical drive
-    void loadFatxDrive(HANDLE deviceHandle);
+    void loadFatxDrive(void* deviceHandle);
 
     // open up a physical drive
     void loadFatxDrive();

--- a/XboxInternals/FATX/FatxDriveDetection.cpp
+++ b/XboxInternals/FATX/FatxDriveDetection.cpp
@@ -1,4 +1,5 @@
 #include "FatxDriveDetection.h"
+#include <Windows.h>
 
 std::vector<FatxDrive*> FatxDriveDetection::GetAllFatxDrives()
 {
@@ -68,9 +69,9 @@ std::vector<FatxDrive*> FatxDriveDetection::GetAllFatxDrives()
     return drives;
 }
 
-std::vector<HANDLE> FatxDriveDetection::getPhysicalDisks()
+std::vector<void*> FatxDriveDetection::getPhysicalDisks()
 {
-    std::vector<HANDLE> physicalDiskPaths;
+    std::vector<void*> physicalDiskPaths;
     std::wstringstream ss;
 
     for (int i = 0; i < 16; i++)
@@ -79,7 +80,7 @@ std::vector<HANDLE> FatxDriveDetection::getPhysicalDisks()
 
         HANDLE drive = CreateFile(ss.str().c_str(), GENERIC_READ|GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
         if (drive != INVALID_HANDLE_VALUE)
-            physicalDiskPaths.push_back(drive);
+            physicalDiskPaths.push_back((void*)drive);
 
         ss.str(std::wstring());
     }

--- a/XboxInternals/FATX/FatxDriveDetection.h
+++ b/XboxInternals/FATX/FatxDriveDetection.h
@@ -1,7 +1,6 @@
 #ifndef FATXDRIVEDETECTION_H
 #define FATXDRIVEDETECTION_H
 
-#include <windows.h>
 #include <iostream>
 #include <vector>
 #include <sstream>
@@ -15,7 +14,7 @@ public:
     static std::vector<FatxDrive*> GetAllFatxDrives();
 
 private:
-    static std::vector<HANDLE> getPhysicalDisks();
+    static std::vector<void*> getPhysicalDisks();
     static std::vector<std::wstring> getLogicalDrives();
 };
 

--- a/XboxInternals/IO/BaseIO.cpp
+++ b/XboxInternals/IO/BaseIO.cpp
@@ -1,4 +1,5 @@
 #include "BaseIO.h"
+#include <vector>
 
 using namespace std;
 
@@ -148,7 +149,9 @@ string BaseIO::ReadString(int len, char nullTerminator, bool forceInclude0, int 
     }
     else
     {
-        char str[len + 1];
+        std::vector<char> strVec;
+        strVec.reserve(len + 1);
+        char* str = strVec.data();
         str[len] = 0;
 
         ReadBytes((BYTE*)str, len);
@@ -241,7 +244,7 @@ void BaseIO::Write(UINT64 u64)
 
 void BaseIO::Write(string s, int forceLen, bool nullTerminating, BYTE nullTerminator)
 {
-    WriteBytes(s.c_str(), s.length() + nullTerminating);
+    WriteBytes((BYTE*)s.c_str(), s.length() + nullTerminating);
 
     if (forceLen > 0)
     {

--- a/XboxInternals/IO/DeviceIO.h
+++ b/XboxInternals/IO/DeviceIO.h
@@ -8,27 +8,11 @@
 #include "../FATX/fatxhelpers.h"
 #include "XboxInternals_global.h"
 
-#ifdef _WIN32
-    #include <windows.h>
-    #include <WinIoCtl.h>
-#else
-    #define _FILE_OFFSET_BITS 64
-    #include <fcntl.h>
-    #include <sys/types.h>
-    #include <sys/ioctl.h>
-    #include <sys/disk.h>
-    #include <unistd.h>
-#endif
-
-#ifndef _WIN32
-    #include <sys/stat.h>
-#endif
-
 
 class XBOXINTERNALSSHARED_EXPORT DeviceIO : public BaseIO
 {
 public:
-    DeviceIO(HANDLE deviceHandle);
+    DeviceIO(void* deviceHandle);
     DeviceIO(std::string devicePath);
     DeviceIO(std::wstring devicePath);
     ~DeviceIO();
@@ -52,13 +36,8 @@ private:
 
     UINT64 realPosition();
 
-    #ifdef _WIN32
-        HANDLE deviceHandle;
-        OVERLAPPED offset;
-    #else
-        int device;
-        INT64 offset;
-    #endif
+    class Impl;
+    Impl* impl;
 
     UINT64 pos;
     BYTE lastReadData[0x200];

--- a/XboxInternals/IO/FatxIO.cpp
+++ b/XboxInternals/IO/FatxIO.cpp
@@ -5,7 +5,7 @@ FatxIO::FatxIO(DeviceIO *device, FatxFileEntry *entry) : device(device), entry(e
     SetPosition(0);
 }
 
-void FatxIO::SetPosition(UINT64 position, std::ios_base::seek_dir dir = std::ios_base::beg)
+void FatxIO::SetPosition(UINT64 position, std::ios_base::seek_dir dir)
 {
     if (dir == std::ios_base::cur)
         position += pos;
@@ -516,7 +516,7 @@ void FatxIO::getConsecutive(std::vector<DWORD> &list, std::vector<Range> &outRan
     }
 }
 
-void FatxIO::SaveFile(std::string savePath, void(*progress)(void*, DWORD, DWORD) = NULL, void *arg = NULL)
+void FatxIO::SaveFile(std::string savePath, void(*progress)(void*, DWORD, DWORD), void *arg)
 {
     // get the current position
     INT64 pos;

--- a/XboxInternals/IO/FileIO.cpp
+++ b/XboxInternals/IO/FileIO.cpp
@@ -1,11 +1,18 @@
 #include "IO/FileIO.h"
+#include <vector>
 
 FileIO::FileIO(string path, bool truncate) :
     BaseIO(), filePath(path)
 {
-    fstr = new fstream(path.c_str(), (std::_Ios_Openmode)(fstream::in | fstream::out | fstream::binary | (fstream::trunc * truncate)));
+    fstr = new fstream(path.c_str(), fstream::in | fstream::out | fstream::binary | (truncate ? fstream::trunc : 0));
     if (!fstr->is_open())
-        throw std::string("FileIO: Error opening the file. " + string(strerror(errno)) + "\n");
+    {
+        std::string ex("FileIO: Error opening the file. ");
+        ex += strerror(errno);
+        ex += "\n";
+        throw ex;
+    }
+
 	endian = BigEndian;
 
     fstr->seekp(0, std::ios_base::end);
@@ -15,7 +22,7 @@ FileIO::FileIO(string path, bool truncate) :
 
 void FileIO::SetPosition(UINT64 pos, ios_base::seek_dir dir)
 {
-    fstr->seekp(pos, (std::_Ios_Seekdir)dir);
+    fstr->seekp(pos, dir);
 }
 
 UINT64 FileIO::GetPosition()
@@ -40,7 +47,9 @@ void FileIO::Flush()
 
 void FileIO::ReverseGenericArray(void *arr, int elemSize, int len)
 {
-    char temp[elemSize];
+	std::vector<char> tempVec;
+	tempVec.reserve(elemSize);
+	char* temp = tempVec.data();
 
 	for (int i = 0; i < (len / 2); i++)
 	{
@@ -57,12 +66,12 @@ string FileIO::GetFilePath()
 
 void FileIO::ReadBytes(BYTE *outBuffer, DWORD len)
 {
-    fstr->read((BYTE*)outBuffer, len);
+    fstr->read((fstream::char_type*)outBuffer, len);
 }
 
 void FileIO::WriteBytes(BYTE *buffer, DWORD len)
 {
-    fstr->write((BYTE*)buffer, len);
+    fstr->write((fstream::char_type*)buffer, len);
 }
 
 FileIO::~FileIO(void)

--- a/XboxInternals/IO/SvodMultiFileIO.cpp
+++ b/XboxInternals/IO/SvodMultiFileIO.cpp
@@ -1,4 +1,5 @@
 #include "SvodMultiFileIO.h"
+#include <dirent.h>
 
 using namespace std;
 
@@ -37,7 +38,8 @@ void SvodMultiFileIO::loadDirectories(string path)
         // load only the files, don't want the folders
         while ((ent = readdir(dir)) != NULL)
         {
-            string fullName = path + string(ent->d_name);
+            string fullName(path);
+            fullName += ent->d_name;
             if (opendir(fullName.c_str()) == NULL)
                 files.push_back(fullName);
         }

--- a/XboxInternals/IO/SvodMultiFileIO.h
+++ b/XboxInternals/IO/SvodMultiFileIO.h
@@ -4,7 +4,6 @@
 #include "IO/FileIO.h"
 #include <iostream>
 #include <vector>
-#include "dirent.h"
 #include "BaseIO.h"
 #include "XboxInternals_global.h"
 

--- a/XboxInternals/Stfs/StfsDefinitions.cpp
+++ b/XboxInternals/Stfs/StfsDefinitions.cpp
@@ -70,7 +70,7 @@ string LicenseTypeToString(LicenseType type)
     }
 }
 
-XBOXINTERNALSSHARED_EXPORT string ByteSizeToString(UINT64 bytes)
+string ByteSizeToString(UINT64 bytes)
 {
     DWORD B = 1; //byte
     DWORD KB = 1024 * B; //kilobyte
@@ -105,7 +105,7 @@ DWORD MSTimeToDWORD(MSTime time)
     return toReturn;
 }
 
-XBOXINTERNALSSHARED_EXPORT MSTime DWORDToMSTime(DWORD winTime)
+MSTime DWORDToMSTime(DWORD winTime)
 {
     MSTime time;
 
@@ -224,7 +224,7 @@ void WriteCertificateEx(Certificate *cert, BaseIO *io, DWORD address)
     io->Write(cert->signature, 0x80);
 }
 
-XBOXINTERNALSSHARED_EXPORT string MagicToString(Magic magic)
+string MagicToString(Magic magic)
 {
     switch (magic)
     {
@@ -252,7 +252,7 @@ string ConsoleTypeToString(ConsoleType type)
     }
 }
 
-XBOXINTERNALSSHARED_EXPORT string ContentTypeToString(ContentType type)
+string ContentTypeToString(ContentType type)
 {
     switch (type)
     {

--- a/XboxInternals/XboxInternals.pro
+++ b/XboxInternals/XboxInternals.pro
@@ -27,7 +27,8 @@ win32 {
     LIBS += C:/botan/libbotan-1.10.a
     PRE_TARGETDEPS += C:/botan/libbotan-1.10.a
     INCLUDEPATH += C:/botan/include
-} else macx|unix {
+}
+macx|unix {
     INCLUDEPATH += /usr/local/include/botan-1.10
     LIBS += /usr/local/lib/libbotan-1.10.a
 }

--- a/XboxInternals/XboxInternals.sln
+++ b/XboxInternals/XboxInternals.sln
@@ -1,0 +1,26 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XboxInternals", "XboxInternals.vcxproj", "{3C75E470-3BEE-478E-A329-8FFBB166F549}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		DebugDll|Win32 = DebugDll|Win32
+		DebugLib|Win32 = DebugLib|Win32
+		ReleaseDll|Win32 = ReleaseDll|Win32
+		ReleaseLibMT|Win32 = ReleaseLibMT|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.DebugDll|Win32.ActiveCfg = DebugDll|Win32
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.DebugDll|Win32.Build.0 = DebugDll|Win32
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.DebugLib|Win32.ActiveCfg = DebugLib|Win32
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.DebugLib|Win32.Build.0 = DebugLib|Win32
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.ReleaseDll|Win32.ActiveCfg = ReleaseDll|Win32
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.ReleaseDll|Win32.Build.0 = ReleaseDll|Win32
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.ReleaseLibMT|Win32.ActiveCfg = ReleaseLibMT|Win32
+		{3C75E470-3BEE-478E-A329-8FFBB166F549}.ReleaseLibMT|Win32.Build.0 = ReleaseLibMT|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/XboxInternals/XboxInternals.vcxproj
+++ b/XboxInternals/XboxInternals.vcxproj
@@ -1,0 +1,224 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="DebugDll|Win32">
+      <Configuration>DebugDll</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="DebugLib|Win32">
+      <Configuration>DebugLib</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseLibMT|Win32">
+      <Configuration>ReleaseLibMT</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseDll|Win32">
+      <Configuration>ReleaseDll</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3C75E470-3BEE-478E-A329-8FFBB166F549}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugLib|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v110_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDll|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v110_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDll|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLibMT|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v110_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='DebugLib|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugDll|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='ReleaseDll|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLibMT|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugLib|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(DIRENT_PATH)\include;$(BOTAN_PATH)\build\include;$(IncludePath)</IncludePath>
+    <OutDir>$(SolutionDir)lib\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDll|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(DIRENT_PATH)\include;$(BOTAN_PATH)\build\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(BOTAN_PATH)\lib\DebugDll;$(LibraryPath)</LibraryPath>
+    <OutDir>$(SolutionDir)lib\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDll|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(DIRENT_PATH)\include;$(BOTAN_PATH)\build\include;$(IncludePath)</IncludePath>
+    <OutDir>$(SolutionDir)lib\$(Configuration)\</OutDir>
+    <LibraryPath>$(BOTAN_PATH)\lib\ReleaseDll;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLibMT|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(DIRENT_PATH)\include;$(BOTAN_PATH)\build\include;$(IncludePath)</IncludePath>
+    <OutDir>$(SolutionDir)lib\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugLib|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>XBOXINTERNALS_LIBRARY;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;_DEBUG;_LIB;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BOTAN_PATH)\build\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDll|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>XBOXINTERNALS_LIBRARY;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;_DEBUG;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BOTAN_PATH)\build\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDll|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>XBOXINTERNALS_LIBRARY;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;NDEBUG;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BOTAN_PATH)\build\include;.;..\%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>botan.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLibMT|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>XBOXINTERNALS_LIBRARY;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;NDEBUG;_LIB;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(BOTAN_PATH)\build\include;.;..\%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="account\Account.cpp" />
+    <ClCompile Include="account\AccountHelpers.cpp" />
+    <ClCompile Include="avatarasset\AssetHelpers.cpp" />
+    <ClCompile Include="avatarasset\AvatarAsset.cpp" />
+    <ClCompile Include="avatarasset\YTGR.cpp" />
+    <ClCompile Include="cryptography\XeCrypt.cpp" />
+    <ClCompile Include="cryptography\XeKeys.cpp" />
+    <ClCompile Include="disc\gdfx.cpp" />
+    <ClCompile Include="disc\svod.cpp" />
+    <ClCompile Include="fatx\FatxDrive.cpp" />
+    <ClCompile Include="fatx\FatxDriveDetection.cpp" />
+    <ClCompile Include="fatx\fatxhelpers.cpp" />
+    <ClCompile Include="gpd\AvatarAwardGPD.cpp" />
+    <ClCompile Include="gpd\DashboardGPD.cpp" />
+    <ClCompile Include="gpd\GameGPD.cpp" />
+    <ClCompile Include="gpd\GPDBase.cpp" />
+    <ClCompile Include="gpd\XDBF.cpp" />
+    <ClCompile Include="gpd\XDBFHelpers.cpp" />
+    <ClCompile Include="io\BaseIO.cpp" />
+    <ClCompile Include="io\DeviceIO.cpp" />
+    <ClCompile Include="io\FatxIO.cpp" />
+    <ClCompile Include="io\FileIO.cpp" />
+    <ClCompile Include="io\MemoryIO.cpp" />
+    <ClCompile Include="io\MultiFileIO.cpp" />
+    <ClCompile Include="io\SvodIO.cpp" />
+    <ClCompile Include="io\SvodMultiFileIO.cpp" />
+    <ClCompile Include="stfs\StfsDefinitions.cpp" />
+    <ClCompile Include="stfs\StfsPackage.cpp" />
+    <ClCompile Include="stfs\XContentHeader.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="account\Account.h" />
+    <ClInclude Include="account\AccountDefinitions.h" />
+    <ClInclude Include="account\AccountHelpers.h" />
+    <ClInclude Include="avatarasset\AssetHelpers.h" />
+    <ClInclude Include="avatarasset\AvatarAsset.h" />
+    <ClInclude Include="avatarasset\AvatarAssetDefinintions.h" />
+    <ClInclude Include="avatarasset\YTGR.h" />
+    <ClInclude Include="cryptography\XeCrypt.h" />
+    <ClInclude Include="cryptography\XeKeys.h" />
+    <ClInclude Include="disc\gdfx.h" />
+    <ClInclude Include="disc\svod.h" />
+    <ClInclude Include="fatx\FatxConstants.h" />
+    <ClInclude Include="fatx\FatxDrive.h" />
+    <ClInclude Include="fatx\FatxDriveDetection.h" />
+    <ClInclude Include="fatx\fatxhelpers.h" />
+    <ClInclude Include="gpd\AvatarAwardGPD.h" />
+    <ClInclude Include="gpd\DashboardGPD.h" />
+    <ClInclude Include="gpd\GameGPD.h" />
+    <ClInclude Include="gpd\GPDBase.h" />
+    <ClInclude Include="gpd\XDBF.h" />
+    <ClInclude Include="gpd\XDBFDefininitions.h" />
+    <ClInclude Include="gpd\XDBFHelpers.h" />
+    <ClInclude Include="io\BaseIO.h" />
+    <ClInclude Include="io\DeviceIO.h" />
+    <ClInclude Include="io\FatxIO.h" />
+    <ClInclude Include="io\FileIO.h" />
+    <ClInclude Include="io\MemoryIO.h" />
+    <ClInclude Include="io\MultiFileIO.h" />
+    <ClInclude Include="io\SvodIO.h" />
+    <ClInclude Include="io\SvodMultiFileIO.h" />
+    <ClInclude Include="stfs\StfsConstants.h" />
+    <ClInclude Include="stfs\StfsDefinitions.h" />
+    <ClInclude Include="stfs\StfsPackage.h" />
+    <ClInclude Include="stfs\XContentHeader.h" />
+    <ClInclude Include="winnames.h" />
+    <ClInclude Include="XboxInternals_global.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/XboxInternals/XboxInternals.vcxproj.filters
+++ b/XboxInternals/XboxInternals.vcxproj.filters
@@ -1,0 +1,216 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="account\Account.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="account\AccountHelpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="avatarasset\AssetHelpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="avatarasset\AvatarAsset.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="avatarasset\YTGR.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cryptography\XeCrypt.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cryptography\XeKeys.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="disc\gdfx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="disc\svod.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="fatx\FatxDrive.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="fatx\FatxDriveDetection.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="fatx\fatxhelpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gpd\AvatarAwardGPD.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gpd\DashboardGPD.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gpd\GameGPD.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gpd\GPDBase.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gpd\XDBF.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="gpd\XDBFHelpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\BaseIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\DeviceIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\FatxIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\FileIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\MemoryIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\MultiFileIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\SvodIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="io\SvodMultiFileIO.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stfs\StfsDefinitions.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stfs\StfsPackage.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stfs\XContentHeader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="winnames.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="XboxInternals_global.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="account\Account.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="account\AccountDefinitions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="account\AccountHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="avatarasset\AssetHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="avatarasset\AvatarAsset.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="avatarasset\AvatarAssetDefinintions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="avatarasset\YTGR.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="cryptography\XeCrypt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="cryptography\XeKeys.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="disc\gdfx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="disc\svod.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fatx\FatxConstants.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fatx\FatxDrive.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fatx\FatxDriveDetection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="fatx\fatxhelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gpd\AvatarAwardGPD.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gpd\DashboardGPD.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gpd\GameGPD.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gpd\GPDBase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gpd\XDBF.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gpd\XDBFDefininitions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gpd\XDBFHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\BaseIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\DeviceIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\FatxIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\FileIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\MemoryIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\MultiFileIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\SvodIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="io\SvodMultiFileIO.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stfs\StfsConstants.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stfs\StfsDefinitions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stfs\StfsPackage.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stfs\XContentHeader.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/XboxInternals/XboxInternals_global.h
+++ b/XboxInternals/XboxInternals_global.h
@@ -1,7 +1,12 @@
 #ifndef XBOXINTERNALS_GLOBAL_H
 #define XBOXINTERNALS_GLOBAL_H
 
-#include <QtCore/qglobal.h>
+#if defined(_MSC_VER) // VC++
+#  define Q_DECL_EXPORT __declspec(dllexport)
+#  define Q_DECL_IMPORT __declspec(dllimport)
+#else
+#  include <QtCore/qglobal.h>
+#endif
 
 #if defined(XBOXINTERNALS_LIBRARY)
 #  define XBOXINTERNALSSHARED_EXPORT Q_DECL_EXPORT


### PR DESCRIPTION
Tested with Visual Studio 2012/VC++ (XP target). Compiles with Qt 4.8.4/MingW (I had to fix the .pro file a little bit first), but haven't done any further testing with Qt.

Also moved Windows-specific code to implementation because macros caused problems after including the headers.
