### PR TITLE
VC++: Static linking with XboxInternals without Qt

### DIFF
--- a/XboxInternals/XboxInternals.vcxproj
+++ b/XboxInternals/XboxInternals.vcxproj
@@ -87,7 +87,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugLib|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>XBOXINTERNALS_LIBRARY;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;_DEBUG;_LIB;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>XBOXINTERNALS_STATIC;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;_DEBUG;_LIB;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(BOTAN_PATH)\build\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -135,7 +135,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLibMT|Win32'">
     <ClCompile>
-      <PreprocessorDefinitions>XBOXINTERNALS_LIBRARY;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;NDEBUG;_LIB;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>XBOXINTERNALS_STATIC;_CRT_SECURE_NO_WARNINGS;__WIN32;WIN32;NDEBUG;_LIB;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(BOTAN_PATH)\build\include;.;..\%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>

--- a/XboxInternals/XboxInternals_global.h
+++ b/XboxInternals/XboxInternals_global.h
@@ -1,17 +1,21 @@
 #ifndef XBOXINTERNALS_GLOBAL_H
 #define XBOXINTERNALS_GLOBAL_H
 
-#if defined(_MSC_VER) // VC++
-#  define Q_DECL_EXPORT __declspec(dllexport)
-#  define Q_DECL_IMPORT __declspec(dllimport)
+#if defined(XBOXINTERNALS_STATIC)
+#  define XBOXINTERNALSSHARED_EXPORT
 #else
-#  include <QtCore/qglobal.h>
-#endif
+#  if defined(_MSC_VER) // VC++
+#    define Q_DECL_EXPORT __declspec(dllexport)
+#    define Q_DECL_IMPORT __declspec(dllimport)
+#  else
+#      include <QtCore/qglobal.h>
+#  endif
 
-#if defined(XBOXINTERNALS_LIBRARY)
-#  define XBOXINTERNALSSHARED_EXPORT Q_DECL_EXPORT
-#else
-#  define XBOXINTERNALSSHARED_EXPORT Q_DECL_IMPORT
+#  if defined(XBOXINTERNALS_LIBRARY)
+#    define XBOXINTERNALSSHARED_EXPORT Q_DECL_EXPORT
+#  else
+#    define XBOXINTERNALSSHARED_EXPORT Q_DECL_IMPORT
+#  endif
 #endif
 
 #endif // XBOXINTERNALS_GLOBAL_H


### PR DESCRIPTION
Added preprocessor define: XBOXINTERNALS_STATIC
It should be used when statically linking with XboxInternals (unless you use Qt, maybe).
