### PR TITLE
Disconnecting a drive while being read may cause infinite loop

### DIFF
--- a/XboxInternals/IO/FileIO.cpp
+++ b/XboxInternals/IO/FileIO.cpp
@@ -67,11 +67,15 @@ string FileIO::GetFilePath()
 void FileIO::ReadBytes(BYTE *outBuffer, DWORD len)
 {
     fstr->read((fstream::char_type*)outBuffer, len);
+    if (fstr->fail())
+        throw string("FileIO: Error reading from file.\n");
 }
 
 void FileIO::WriteBytes(BYTE *buffer, DWORD len)
 {
     fstr->write((fstream::char_type*)buffer, len);
+    if (fstr->fail())
+        throw string("FileIO: Error writing to file.\n");
 }
 
 FileIO::~FileIO(void)


### PR DESCRIPTION
More specifically, FileIO doesn't check if read/write failed, and code using it may keep trying to read data, e.g. in FatxDrive::ReadClusterChain(). The result is that the program will freeze.

Now throws exception on failure. Not sure if other checks are necessary, so it only checks read/write this time.

If the error is caused by the user disconnecting a USB device, the user probably doesn't see the USB device itself as a "file", and the exception message "Error reading from file" may in that case seem misleading.

Still, I think it's better than the program freezing.

Another idea is to set the exception mask for the stream so that a more specific exception type is thrown. Please see this:
http://www.cplusplus.com/reference/ios/ios/exceptions/

Since std::string is thrown pretty much everywhere already, I followed that practice.
