### PR TITLE
Fixed memory leaks in IO classes.

### DIFF
--- a/XboxInternals/IO/BaseIO.cpp
+++ b/XboxInternals/IO/BaseIO.cpp
@@ -9,6 +9,11 @@ BaseIO::BaseIO() :
     // should be implemented by derived class
 }
 
+BaseIO::~BaseIO()
+{
+
+}
+
 void BaseIO::SetEndian(EndianType byteOrder)
 {
     this->byteOrder = byteOrder;

--- a/XboxInternals/IO/BaseIO.h
+++ b/XboxInternals/IO/BaseIO.h
@@ -20,6 +20,7 @@ class XBOXINTERNALSSHARED_EXPORT BaseIO
 {
 public:
     BaseIO();
+    virtual ~BaseIO();
 
     // set the byte order in which to read the bytes
     void SetEndian(EndianType byteOrder);

--- a/XboxInternals/IO/DeviceIO.h
+++ b/XboxInternals/IO/DeviceIO.h
@@ -15,7 +15,7 @@ public:
     DeviceIO(void* deviceHandle);
     DeviceIO(std::string devicePath);
     DeviceIO(std::wstring devicePath);
-    ~DeviceIO();
+    virtual ~DeviceIO();
 
     void ReadBytes(BYTE *outBuffer, DWORD len);
 

--- a/XboxInternals/IO/FatxIO.cpp
+++ b/XboxInternals/IO/FatxIO.cpp
@@ -7,6 +7,11 @@ FatxIO::FatxIO(DeviceIO *device, FatxFileEntry *entry) : device(device), entry(e
         SetPosition(0);
 }
 
+FatxIO::~FatxIO()
+{
+
+}
+
 void FatxIO::SetPosition(UINT64 position, std::ios_base::seek_dir dir)
 {
     if (dir == std::ios_base::cur)

--- a/XboxInternals/IO/FatxIO.h
+++ b/XboxInternals/IO/FatxIO.h
@@ -21,6 +21,7 @@ class XBOXINTERNALSSHARED_EXPORT FatxIO : public BaseIO
 {
 public:
     FatxIO(DeviceIO *device, FatxFileEntry *entry);
+    virtual ~FatxIO();
 
     // get the current file entry
     FatxFileEntry *GetFatxFileEntry();

--- a/XboxInternals/IO/FileIO.h
+++ b/XboxInternals/IO/FileIO.h
@@ -30,7 +30,7 @@ public:
     string GetFilePath();
 
     static void ReverseGenericArray(void *arr, int elemSize, int len);
-	~FileIO();
+	virtual ~FileIO();
 private:
 	EndianType endian;
     UINT64 length;

--- a/XboxInternals/IO/MemoryIO.cpp
+++ b/XboxInternals/IO/MemoryIO.cpp
@@ -6,6 +6,11 @@ MemoryIO::MemoryIO(BYTE *data, size_t length) :
 
 }
 
+MemoryIO::~MemoryIO()
+{
+
+}
+
 void MemoryIO::SetPosition(UINT64 pos, std::ios_base::seek_dir dir)
 {
     DWORD newPos;

--- a/XboxInternals/IO/MemoryIO.h
+++ b/XboxInternals/IO/MemoryIO.h
@@ -9,6 +9,7 @@ class XBOXINTERNALSSHARED_EXPORT MemoryIO : public BaseIO
 {
 public:
     MemoryIO(BYTE *data, size_t length);
+    virtual ~MemoryIO();
 
     void SetPosition(UINT64 pos, std::ios_base::seek_dir dir = std::ios_base::beg);
     UINT64 GetPosition();

--- a/XboxInternals/IO/MultiFileIO.cpp
+++ b/XboxInternals/IO/MultiFileIO.cpp
@@ -16,6 +16,11 @@ MultiFileIO::MultiFileIO(std::vector<BaseIO*> files) : files(files), currentIOIn
     calcualteLengthOfAllFiles();
 }
 
+MultiFileIO::~MultiFileIO()
+{
+
+}
+
 void MultiFileIO::SetPosition(UINT64 position, std::ios_base::seek_dir dir)
 {
     if (dir == std::ios_base::end)

--- a/XboxInternals/IO/MultiFileIO.h
+++ b/XboxInternals/IO/MultiFileIO.h
@@ -12,6 +12,7 @@ class XBOXINTERNALSSHARED_EXPORT MultiFileIO : public BaseIO
 public:
     MultiFileIO(std::vector<std::string> filePaths);
     MultiFileIO(std::vector<BaseIO*> files);
+    virtual ~MultiFileIO();
 
     // seek to a position in a file
     void SetPosition(UINT64 position, std::ios_base::seek_dir dir = std::ios_base::beg);

--- a/XboxInternals/IO/SvodIO.cpp
+++ b/XboxInternals/IO/SvodIO.cpp
@@ -11,6 +11,11 @@ SvodIO::SvodIO(XContentHeader *metadata, GdfxFileEntry entry, SvodMultiFileIO *i
     io->SetPosition(addr, index);
 }
 
+SvodIO::~SvodIO()
+{
+
+}
+
 void SvodIO::SectorToAddress(DWORD sector, DWORD *addressInDataFile, DWORD *dataFileIndex)
 {
     DWORD trueSector = (sector - (metadata->svodVolumeDescriptor.dataBlockOffset * 2)) % 0x14388;

--- a/XboxInternals/IO/SvodIO.h
+++ b/XboxInternals/IO/SvodIO.h
@@ -11,6 +11,8 @@ class XBOXINTERNALSSHARED_EXPORT SvodIO : public BaseIO
 public:
     SvodIO(XContentHeader *metadata, GdfxFileEntry entry, SvodMultiFileIO *io);
 
+    virtual ~SvodIO();
+
     void ReadBytes(BYTE *outBuffer, DWORD len);
 
     void WriteBytes(BYTE *buffer, DWORD len);

--- a/XboxInternals/IO/SvodMultiFileIO.h
+++ b/XboxInternals/IO/SvodMultiFileIO.h
@@ -15,7 +15,7 @@ class XBOXINTERNALSSHARED_EXPORT SvodMultiFileIO : public BaseIO
 {
 public:
     SvodMultiFileIO(string fileDirectory);
-    ~SvodMultiFileIO();
+    virtual ~SvodMultiFileIO();
 
     // seek to a certain address in the file, index of -1 for current file
     void SetPosition(DWORD addressInFile, int fileIndex = -1);


### PR DESCRIPTION
Use virtual destructor in base classes to avoid leaks. Would be a good habit to always use them.
