### PR TITLE
VC++: Fixed compile errors

### DIFF
--- a/XboxInternals/IO/FileIO.cpp
+++ b/XboxInternals/IO/FileIO.cpp
@@ -23,7 +23,7 @@ FileIO::FileIO(string path, bool truncate) :
 
 void FileIO::SetPosition(UINT64 pos, ios_base::seek_dir dir)
 {
-    fstr->seekp(pos, static_cast<std::_Ios_Seekdir>(dir));
+    fstr->seekp(pos, static_cast<std::ios_base::seekdir>(dir));
 }
 
 UINT64 FileIO::GetPosition()

--- a/XboxInternals/winnames.h
+++ b/XboxInternals/winnames.h
@@ -2,7 +2,18 @@
 #define WINNAMES_H
 
 #ifdef _WIN32
-    #include <windows.h>
+    // Visual C++: Avoid the Windows header to prevent a macro mess.
+    // NOTES: This is not a complete fix. It's best to avoid Windows headers in our own headers.
+    #ifdef _MSC_VER
+        typedef unsigned char BYTE;
+        typedef unsigned short WORD;
+        typedef unsigned long DWORD;
+        typedef int INT32;
+        typedef signed __int64 INT64;
+        typedef unsigned __int64 UINT64;
+    #else
+        #include <windows.h>
+    #endif
 #else
 typedef unsigned char BYTE;
 typedef unsigned short WORD;


### PR DESCRIPTION
I have not checked if this causes problems for other compilers. I believe it's good practice to avoid the Windows headers, inside our own headers. Including Windows headers usually causes all sorts of macro/define problems for users of the library, 3rd party libraries (Botan), and even inside the library itself.
