### PR TITLE
Fix problems with detection of USB drives on linux and exceptions handling

### DIFF
--- a/Velocity/deviceviewer.cpp
+++ b/Velocity/deviceviewer.cpp
@@ -405,7 +405,7 @@ void DeviceViewer::LoadDrives()
     }
     catch (std::string error)
     {
-        QMessageBox::warning(this, "Problem Loading", "The drive failed to load.\n\n" + QString::fromStdString(error));
+        QMessageBox::critical(this, "Problem Loading", "The drive failed to load.\n\n" + QString::fromStdString(error));
     }
 }
 


### PR DESCRIPTION
Not all linux distributions mount USB drives to /media. We should
rather iterate through all mountpoints, which can be found in
/proc/mounts, and test them.
Also, exceptions raised in GetAllFatxDrives() should be handled in
GUI so we can show an error dialog.
