### PR TITLE
migrate to Qt6, Botan 3, make it work on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ moc_*.h
 moc_*.cpp
 ui_*.h
 qrc_Resources.cpp
+.qmake.stash
 
 # Velocity #
 ############

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,35 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include",
+                "/opt/homebrew/include",
+                "/opt/homebrew/opt/qt/Frameworks/QtWidgets.framework/Versions/Current/Headers",
+                "/opt/homebrew/opt/qt/Frameworks/QtGui.framework/Versions/Current/Headers",
+                "/opt/homebrew/opt/qt/Frameworks/QtCore.framework/Versions/Current/Headers",
+                "/opt/homebrew/opt/qt/Frameworks/QtNetwork.framework/Versions/Current/Headers",
+                "/opt/homebrew/include/botan-3"
+            ],
+            "defines": [
+                "XBOXINTERNALS_LIBRARY",
+                "QT_CORE_LIB",
+                "Q_OS_MAC",
+                "QT_WIDGETS_LIB",
+                "QT_GUI_LIB"
+            ],
+            "macFrameworkPath": [
+                "/System/Library/Frameworks",
+                "/Library/Frameworks",
+                "/opt/homebrew/opt/qt/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++20",
+            "intelliSenseMode": "macos-clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Velocity.app",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/Velocity/Velocity.app/Contents/MacOS/Velocity",
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "lldb",
+            "preLaunchTask": "build",
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "type": "shell",
+            "command": "make",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$gcc",
+        }
+    ]
+}

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -22,7 +22,7 @@ The Qt Creator IDE is used to build/debug Velocity. Velocity currently depends o
 	
 	The installation process differs depending on distribution. For example:
 	
-	Ubuntu: `apt-get install libbotan-1.10-0`  
+	Ubuntu: `apt-get install libbotan-3-0`  
 	Arch Linux: `pacman -S botan`
 	
 ==========

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -1,32 +1,32 @@
-The Qt Creator IDE is used to build/debug Velocity. Velocity currently depends on Qt4 and Botan 1.10.
+The Qt Creator IDE is used to build/debug Velocity. Velocity currently depends on Qt6 and Botan 3.4
 
 ==========
 
 - WINDOWS
-	
-	While debugging, Velocity is compiled with 'Qt 4.8.1 for Desktop - MingGW (Qt SDK) Debug'.
-	While compiling for release mode, Velocity is compiled with 'Qt 4.8.1 for Desktop - MingGW (Qt SDK) Release'.
-	
+
+	While debugging, Velocity is compiled with 'Qt 6.7 for Desktop - MingGW (Qt SDK) Debug'.
+	While compiling for release mode, Velocity is compiled with 'Qt 6.7 for Desktop - MingGW (Qt SDK) Release'.
+
 	Tool Chain: 'Mingw as a GCC for Windows targets'
-	
+
 	WARNING: Botan must be found in the working directory of Velocity.exe for Velocity to successfully run. To obtain the Botan libraries, you have 2 options:
-	
+
 	1. Download the Botan sources from http://botan.randombit.net/download.html.
 	2. Download the Botan binary (.a) from http://www.mediafire.com/?o5zhbb4leufk8d7, if available.
-	
+
 - MAC
-	
+
 	Botan can be installed using Homebrew by typing `brew install botan` into your terminal.
 
 - LINUX
-	
+
 	The installation process differs depending on distribution. For example:
-	
-	Ubuntu: `apt-get install libbotan-3-0`  
+
+	Ubuntu: `apt-get install libbotan-3-0`
 	Arch Linux: `pacman -S botan`
-	
+
 ==========
 
-If you do not want to use Qt Creator IDE, you can use Makefile in the root directory of the project.  
-The Makefile builds Velocity with debug configuration by default, but one can explicitly set desired configuration as the parameter like this:  
+If you do not want to use Qt Creator IDE, you can use Makefile in the root directory of the project.
+The Makefile builds Velocity with debug configuration by default, but one can explicitly set desired configuration as the parameter like this:
 `make debug` or `make release`

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ libXboxInternals: XboxInternals/
 	mkdir -p XboxInternals-$(OS)/$(CONFIG)
 	cp XboxInternals/libXboxInternals.* XboxInternals-$(OS)/$(CONFIG)
 
-velocity: Velocity/
+velocity_target: Velocity/
 	$(QMAKE) Velocity/Velocity.pro -o Velocity/Makefile CONFIG+=$(CONFIG)
 	make -C Velocity
 
-modules: libXboxInternals velocity
+modules: libXboxInternals velocity_target
 
 debug: CONFIG = debug
 debug: modules

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-QMAKE = qmake-qt4
+QMAKE = qmake
 UNAME = $(shell uname -s)
 
 ifeq ($(UNAME), Linux)

--- a/Velocity/Velocity.pro
+++ b/Velocity/Velocity.pro
@@ -27,9 +27,9 @@ macx {
     INCLUDEPATH += /opt/homebrew/include/botan-3
     LIBS += /opt/homebrew/lib/libbotan-3.a
 }
-unix {
-    INCLUDEPATH += /usr/include/botan-1.10
-    LIBS += /usr/lib/libbotan-1.10.so.0
+else:unix {
+    INCLUDEPATH += /usr/include/botan-3
+    LIBS += /usr/lib/libbotan-3.so.0
 }
 
 # phonon, icon

--- a/Velocity/Velocity.pro
+++ b/Velocity/Velocity.pro
@@ -22,8 +22,8 @@ win32 {
     INCLUDEPATH += C:/botan/include
 }
 macx {
-    INCLUDEPATH += /usr/local/include/botan-1.10
-    LIBS += /usr/local/lib/libbotan-1.10.a
+    INCLUDEPATH += /opt/homebrew/include/botan-3
+    LIBS += /opt/homebrew/lib/libbotan-3.a
 }
 unix {
     INCLUDEPATH += /usr/include/botan-1.10

--- a/Velocity/Velocity.pro
+++ b/Velocity/Velocity.pro
@@ -10,6 +10,8 @@ QT       += core gui network xml widgets
 TARGET = Velocity
 TEMPLATE = app
 
+CONFIG += c++20
+
 win32:UI_DIR = ../Velocity
 
 # application version

--- a/Velocity/achievementcreationwizard.cpp
+++ b/Velocity/achievementcreationwizard.cpp
@@ -109,7 +109,7 @@ void AchievementCreationWizard::onFinished(int result)
         achievement->structSize = 0x1C;
 
         // set the thumbnail image
-        *achThumbnail = ui->imgThumbnail->pixmap()->toImage();
+        *achThumbnail = ui->imgThumbnail->pixmap().toImage();
     }
 }
 

--- a/Velocity/creationwizard.cpp
+++ b/Velocity/creationwizard.cpp
@@ -176,14 +176,14 @@ void CreationWizard::onFinished(int status)
         QByteArray ba1;
         QBuffer buffer1(&ba1);
         buffer1.open(QIODevice::WriteOnly);
-        ui->imgThumbnail->pixmap()->save(&buffer1, "PNG");
+        ui->imgThumbnail->pixmap().save(&buffer1, "PNG");
         package.metaData->thumbnailImage = (BYTE*)ba1.data();
         package.metaData->thumbnailImageSize = ba1.length();
 
         QByteArray ba2;
         QBuffer buffer2(&ba2);
         buffer2.open(QIODevice::WriteOnly);
-        ui->imgTitleThumbnail->pixmap()->save(&buffer2, "PNG");
+        ui->imgTitleThumbnail->pixmap().save(&buffer2, "PNG");
         package.metaData->titleThumbnailImage = (BYTE*)ba2.data();
         package.metaData->titleThumbnailImageSize = ba2.length();
 

--- a/Velocity/deviceviewer.cpp
+++ b/Velocity/deviceviewer.cpp
@@ -78,7 +78,7 @@ void DeviceViewer::DrawMemoryGraph()
 
     // draw the insano piechart
     QPixmap chart(750, 500);
-    chart.fill(ui->imgPiechart->palette().background().color());
+    chart.fill(ui->imgPiechart->palette().window().color());
     QPainter painter(&chart);
     Nightcharts pieChart;
     pieChart.setType(Nightcharts::Dpie);

--- a/Velocity/deviceviewer.cpp
+++ b/Velocity/deviceviewer.cpp
@@ -273,7 +273,7 @@ void DeviceViewer::showContextMenu(QPoint point)
                     QDate date;
                     date.setDate(createdtime.year, createdtime.month, createdtime.monthDay);
 
-                    entryItem->setText(2, date.toString(Qt::DefaultLocaleShortDate));
+                    entryItem->setText(2, date.toString(QLocale::system().dateFormat(QLocale::ShortFormat)));
                 }
             }
         }
@@ -553,7 +553,7 @@ void DeviceViewer::LoadFolderAll(FatxFileEntry *folder)
             QDate date;
             date.setDate(createdtime.year, createdtime.month, createdtime.monthDay);
 
-            entryItem->setText(2, date.toString(Qt::DefaultLocaleShortDate));
+            entryItem->setText(2, date.toString(QLocale::system().dateFormat(QLocale::ShortFormat)));
 
             if (i % 25 == 0)
                 QApplication::processEvents();

--- a/Velocity/fatxpathgendialog.cpp
+++ b/Velocity/fatxpathgendialog.cpp
@@ -9,8 +9,8 @@ FATXPathGenDialog::FATXPathGenDialog(StfsPackage *package, QWidget *parent) :
     // the general path for packages is: Data\Content\ProfileID\TitleID\ContentType
     ui->txtPath->setText("Data\\Content\\" +
             QtHelpers::ByteArrayToString(package->metaData->profileID, 8, false) + "\\" +
-            QString().sprintf("%8X", package->metaData->titleID).replace(" ", "0") + "\\" +
-            QString().sprintf("%8X", package->metaData->contentType).replace(" ", "0") + "\\");
+            QString("%1").arg(package->metaData->titleID, 8, 16, QChar('0')).toUpper() + "\\" +
+            QString("%1").arg(package->metaData->contentType, 8, 16, QChar('0')).toUpper() + "\\");    
 }
 
 FATXPathGenDialog::~FATXPathGenDialog()

--- a/Velocity/gameadderdialog.cpp
+++ b/Velocity/gameadderdialog.cpp
@@ -46,7 +46,7 @@ GameAdderDialog::GameAdderDialog(StfsPackage *package, QWidget *parent, bool dis
     manager = new QNetworkAccessManager(this);
 
     // check for a connection
-    if (manager->networkAccessible() == QNetworkAccessManager::NotAccessible)
+    if (QNetworkInformation::instance()->reachability() != QNetworkInformation::Reachability::Online)
     {
         QMessageBox::warning(this, "Listing Error",
                 "The listing could not be parsed. Try again later, as the servers may be down and make sure Velocity has access to the internet.");

--- a/Velocity/gameadderdialog.cpp
+++ b/Velocity/gameadderdialog.cpp
@@ -637,7 +637,7 @@ void GameAdderDialog::on_txtSearch_textChanged(const QString & /* arg1 */)
 
     // hide all the items
     for (int i = 0; i < ui->treeWidgetAllGames->topLevelItemCount(); i++)
-        ui->treeWidgetAllGames->setItemHidden(ui->treeWidgetAllGames->topLevelItem(i), true);
+        ui->treeWidgetAllGames->topLevelItem(i)->setHidden(true);
 
     if (itemsMatched.count() == 0)
     {
@@ -654,13 +654,13 @@ void GameAdderDialog::on_txtSearch_textChanged(const QString & /* arg1 */)
         QTreeWidgetItem *parent = itemsMatched.at(i)->parent();
         while (parent != NULL)
         {
-            ui->treeWidgetAllGames->setItemHidden(parent, false);
+            parent->setHidden(false);
             parent->setExpanded(true);
             parent = parent->parent();
         }
 
         // show the item itself
-        ui->treeWidgetAllGames->setItemHidden(itemsMatched.at(i), false);
+        itemsMatched.at(i)->setHidden(false);
     }
 }
 

--- a/Velocity/gameadderdialog.cpp
+++ b/Velocity/gameadderdialog.cpp
@@ -148,7 +148,7 @@ void GameAdderDialog::gameReplyFinished(QNetworkReply *aReply)
             .femaleAvatarAwardsEarned = 0,
             .femaleAvatarAwardCount = (BYTE)femaleAwardCount.toInt(),
             .flags = 0,
-            .lastPlayed = QDateTime::currentDateTime().toTime_t(),
+            .lastPlayed = QDateTime::currentDateTime().currentSecsSinceEpoch(),
             .gameName = gameName.toStdWString()
         };
 

--- a/Velocity/gameadderdialog.h
+++ b/Velocity/gameadderdialog.h
@@ -5,6 +5,7 @@
 #include <QDialog>
 #include <QNetworkRequest>
 #include <QNetworkAccessManager>
+#include <QNetworkInformation>
 #include <QNetworkReply>
 #include <QTreeWidgetItem>
 #include <QDateTime>

--- a/Velocity/gamerpicturepackdialog.cpp
+++ b/Velocity/gamerpicturepackdialog.cpp
@@ -83,7 +83,7 @@ void GamerPicturePackDialog::gamercardNetworkReply(QNetworkReply *reply)
     {
         // setup
         QString pageSource(reply->readAll());
-        QRegExp exp("<title>([^<]*).*<img id=\"Gamerpic\" src=\"([^\"]*)");
+        QRegularExpression exp("<title>([^<]*).*<img id=\"Gamerpic\" src=\"([^\"]*)");
 
         exp.indexIn(pageSource, 0);
 

--- a/Velocity/gamerpicturepackdialog.cpp
+++ b/Velocity/gamerpicturepackdialog.cpp
@@ -180,8 +180,8 @@ void GamerPicturePackDialog::onTitleIDSearchReturn(QList<TitleData> titlesFound)
     // display all the titles found in the widget
     for (int i = 0; i < titlesFound.size(); i++)
     {
-        QString newStr = ((QString*)&titlesFound.at(i).titleName)->replace("&#174;", "®").replace("&#39;",
-                "'").replace("&amp;","&").replace("&gt;",">").replace("&lt;","<").replace("â", "").replace("¢", "");
+        QString newStr = ((QString*)&titlesFound.at(i).titleName)->replace("&#174;", "Â®").replace("&#39;",
+                "'").replace("&amp;","&").replace("&gt;",">").replace("&lt;","<").replace("Ã¢", "").replace("Â¢", "");
         ui->listGameNames->addItem(newStr);
     }
 }

--- a/Velocity/gamerpicturepackdialog.cpp
+++ b/Velocity/gamerpicturepackdialog.cpp
@@ -85,10 +85,12 @@ void GamerPicturePackDialog::gamercardNetworkReply(QNetworkReply *reply)
         QString pageSource(reply->readAll());
         QRegularExpression exp("<title>([^<]*).*<img id=\"Gamerpic\" src=\"([^\"]*)");
 
-        exp.indexIn(pageSource, 0);
+        QRegularExpressionMatch match = exp.match(pageSource);
+        if (!match.hasMatch())
+            return;
 
         // request image
-        QString gamertag = exp.cap(1);
+        QString gamertag = match.captured(1);
         ui->txtSearch->setText(gamertag);
 
         if (searchedGamertags.contains(gamertag))
@@ -96,7 +98,7 @@ void GamerPicturePackDialog::gamercardNetworkReply(QNetworkReply *reply)
 
         searchedGamertags.push_back(gamertag);
 
-        QString urlStr = exp.cap(2);
+        QString urlStr = match.captured(2);
         QUrl url(urlStr);
 
         if (url.host() == "avatar.xboxlive.com")

--- a/Velocity/gamerpicturepackdialog.cpp
+++ b/Velocity/gamerpicturepackdialog.cpp
@@ -493,7 +493,7 @@ bool GamerPicturePackDialog::verifyGamertag(QString gamertag)
     if (gamertag.length() == 0 || gamertag.length() > 15 || !gamertag.at(0).isLetter())
         return false;
 
-    QChar prevChar = 0;
+    QChar prevChar(0);
     for (int i = 1; i < gamertag.length(); i++)
     {
         if (gamertag.at(i) == ' ' && prevChar == ' ')

--- a/Velocity/githubcommitsdialog.cpp
+++ b/Velocity/githubcommitsdialog.cpp
@@ -27,7 +27,7 @@ GitHubCommitsDialog::GitHubCommitsDialog(QWidget *parent) :
     label->setWordWrap(true);
 
     // make sure we can connect to the internet
-    if (commitsManager->networkAccessible() == QNetworkAccessManager::NotAccessible)
+    if (QNetworkInformation::instance()->reachability() != QNetworkInformation::Reachability::Online)
     {
         label->setText("<center>Error connecting to GitHub...</center>");
         return;

--- a/Velocity/githubcommitsdialog.cpp
+++ b/Velocity/githubcommitsdialog.cpp
@@ -103,7 +103,7 @@ void GitHubCommitsDialog::onCommitsReply(QNetworkReply *reply)
 
     if (++retrievedCount == branchCount)
     {
-        qSort(allCommits.begin(), allCommits.end(), commitCompare);
+        std::sort(allCommits.begin(), allCommits.end(), commitCompare);
 
         int iterations = (allCommits.size() > 20) ? 20 : allCommits.size();
         for (int i = 0; i < iterations; i++)

--- a/Velocity/githubcommitsdialog.h
+++ b/Velocity/githubcommitsdialog.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <QLabel>
 #include <QNetworkAccessManager>
+#include <QNetworkInformation>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QDateTime>

--- a/Velocity/gpduploader.cpp
+++ b/Velocity/gpduploader.cpp
@@ -195,9 +195,9 @@ void GpdUploader::sendRequest(QString filePath, QString awardFilePath, QString g
         QByteArray dataToSend;
 
         // add data to the variable to be sent
-        dataToSend.append("\r\n--" + boundary + "\r\n");
-        dataToSend.append("Content-Disposition: form-data; name=\"game\"; filename=\"" + titleID.toUpper() +
-                ".gpd\"\r\n");
+        dataToSend.append(("\r\n--" + boundary + "\r\n").toUtf8());
+        dataToSend.append(("Content-Disposition: form-data; name=\"game\"; filename=\"" + titleID.toUpper() +
+                ".gpd\"\r\n").toUtf8());
         dataToSend.append("Content-Type: application/octet-stream\r\n\r\n");
         dataToSend.append(gpdFile.readAll());
 
@@ -208,13 +208,13 @@ void GpdUploader::sendRequest(QString filePath, QString awardFilePath, QString g
                 qDebug() << "failed to remove gpd file";
 
         // setup next boundary
-        dataToSend.append("\r\n--" + boundary + "\r\n");
+        dataToSend.append(("\r\n--" + boundary + "\r\n").toUtf8());
 
         // add the award gpd to the data to be sent, if there is an award gpd
         if (awardFilePath != "")
         {
-            dataToSend.append("Content-Disposition: form-data; name=\"award\"; filename=\"" + titleID.toUpper()
-                    + ".gpd\"\r\n");
+            dataToSend.append(("Content-Disposition: form-data; name=\"award\"; filename=\"" + titleID.toUpper()
+                    + ".gpd\"\r\n").toUtf8());
             dataToSend.append("Content-Type: application/octet-stream\r\n\r\n");
             dataToSend.append(awardFile.readAll());
 
@@ -229,7 +229,7 @@ void GpdUploader::sendRequest(QString filePath, QString awardFilePath, QString g
         }
 
         // end the data to be sent
-        dataToSend.append("\r\n--" + boundary + "--\r\n");
+        dataToSend.append(("\r\n--" + boundary + "--\r\n").toUtf8());
 
         // set the network request
         QNetworkRequest request(QUrl("http://velocity.expetelek.com/gameadder/add.php" + getData));

--- a/Velocity/main.cpp
+++ b/Velocity/main.cpp
@@ -5,7 +5,6 @@
 #endif
 
 #include <QStringList>
-#include <botan/botan.h>
 #include "mainwindow.h"
 
 int main(int argc, char *argv[])
@@ -16,8 +15,6 @@ int main(int argc, char *argv[])
     QList<QUrl> args;
     for (int i = 1; i < argc; i++)
         args.append(QUrl("file:///" + QString::fromLatin1(argv[i]).replace("\\", "/")));
-
-    Botan::LibraryInitializer init;
 
     MainWindow w(args);
     w.show();

--- a/Velocity/main.cpp
+++ b/Velocity/main.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <QStringList>
+#include <QNetworkInformation>
 #include "mainwindow.h"
 
 int main(int argc, char *argv[])
@@ -15,6 +16,8 @@ int main(int argc, char *argv[])
     QList<QUrl> args;
     for (int i = 1; i < argc; i++)
         args.append(QUrl("file:///" + QString::fromLatin1(argv[i]).replace("\\", "/")));
+
+    QNetworkInformation::loadDefaultBackend();
 
     MainWindow w(args);
     w.show();

--- a/Velocity/mainwindow.ui
+++ b/Velocity/mainwindow.ui
@@ -25,7 +25,7 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QGridLayout" name="gridLayout">
-    <property name="margin">
+    <property name="margin" stdset="0">
      <number>0</number>
     </property>
     <item row="0" column="0">
@@ -64,7 +64,7 @@
      <x>0</x>
      <y>0</y>
      <width>1013</width>
-     <height>21</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -237,9 +237,6 @@
    <property name="text">
     <string>Profile Creator</string>
    </property>
-   <property name="softKeyRole">
-    <enum>QAction::NoSoftKey</enum>
-   </property>
    <property name="iconVisibleInMenu">
     <bool>true</bool>
    </property>
@@ -247,9 +244,6 @@
   <action name="actionProfile_Editor">
    <property name="text">
     <string>Profile Editor</string>
-   </property>
-   <property name="softKeyRole">
-    <enum>QAction::NoSoftKey</enum>
    </property>
    <property name="iconVisibleInMenu">
     <bool>true</bool>

--- a/Velocity/metadata.cpp
+++ b/Velocity/metadata.cpp
@@ -346,7 +346,7 @@ Metadata::Metadata(QStatusBar *statusBar, XContentHeader *header, bool pec, QWid
 
                 // last modified
                 lastModified = new QDateTimeEdit(this);
-                lastModified->setDateTime(QDateTime::fromTime_t(header->lastModified));
+                lastModified->setDateTime(QDateTime::fromSecsSinceEpoch(header->lastModified));
 
                 ui->tableWidget->insertRow(31 + offset);
                 ui->tableWidget->setVerticalHeaderItem(31 + offset, new QTableWidgetItem("Last Modified"));
@@ -652,7 +652,7 @@ void Metadata::on_pushButton_clicked()
             header->currentFileIndex = ui->tableWidget->item(28 + offset, 0)->text().toULong();
             header->currentFileOffset = ui->tableWidget->item(29 + offset, 0)->text().toULongLong();
             header->bytesProcessed = ui->tableWidget->item(30 + offset, 0)->text().toULongLong();
-            header->lastModified = lastModified->dateTime().toTime_t();
+            header->lastModified = lastModified->dateTime().currentSecsSinceEpoch();
         }
     }
 

--- a/Velocity/nightcharts.cpp
+++ b/Velocity/nightcharts.cpp
@@ -317,13 +317,13 @@ int Nightcharts::draw(QPainter *painter)
         painter->setPen(Qt::SolidLine);
         for (int i=1; i<10; i++)
         {
-            painter->drawLine(cX-3,cY+cH/10*i,cX+3,cY+cH/10*i);    //äåëåíèÿ ïî îñè Y
+            painter->drawLine(cX-3,cY+cH/10*i,cX+3,cY+cH/10*i);    //Ã¤Ã¥Ã«Ã¥Ã­Ã¨Ã¿ Ã¯Ã® Ã®Ã±Ã¨ Y
             //painter->drawText(cX-20,cY+cH/10*i,QString::number((10-i)*10)+"%");
         }
-        painter->drawLine(cX,cY+cH,cX,cY);         //îñü Y
-        painter->drawLine(cX,cY,cX+4,cY+10);       //ñòðåëêè
+        painter->drawLine(cX,cY+cH,cX,cY);         //Ã®Ã±Ã¼ Y
+        painter->drawLine(cX,cY,cX+4,cY+10);       //Ã±Ã²Ã°Ã¥Ã«ÃªÃ¨
         painter->drawLine(cX,cY,cX-4,cY+10);
-        painter->drawLine(cX,cY+cH,cX+cW,cY+cH);   //îñü Õ
+        painter->drawLine(cX,cY+cH,cX+cW,cY+cH);   //Ã®Ã±Ã¼ Ã•
 
     }
     return 0;

--- a/Velocity/nightcharts.cpp
+++ b/Velocity/nightcharts.cpp
@@ -345,7 +345,7 @@ int Nightcharts::drawLegend(QPainter *painter)
             painter->setBrush(Qt::white);
             float x = cX;
             float y = cY+cH+20+dist;
-            //painter->drawRoundRect(cX+cW+20,cY,dist*2+200,pieces.size()*(fontmetr.height()+2*dist)+dist,15,15);
+            //painter->drawRoundedRect(cX+cW+20,cY,dist*2+200,pieces.size()*(fontmetr.height()+2*dist)+dist,15,15);
             for (int i=0;i<pieces.size();i++)
             {
                 painter->setBrush(pieces[i].rgbColor);
@@ -366,7 +366,7 @@ int Nightcharts::drawLegend(QPainter *painter)
         {
             int dist = 5;
             painter->setBrush(Qt::white);
-            //painter->drawRoundRect(cX+cW+20,cY,dist*2+200,pieces.size()*(painter->fontMetrics().height()+2*dist)+dist,15,15);
+            //painter->drawRoundedRect(cX+cW+20,cY,dist*2+200,pieces.size()*(painter->fontMetrics().height()+2*dist)+dist,15,15);
             for (int i=pieces.size()-1; i>=0; i--)
             {
                 painter->setBrush(pieces[i].rgbColor);
@@ -399,7 +399,7 @@ int Nightcharts::drawLegend(QPainter *painter)
                 p_.setX(p_.x()-recW/2 + recW/2*cos(angle*M_PI/180));
                 p_.setY(p_.y()+recH/2 + recH/2*sin(angle*M_PI/180));
                 painter->setBrush(Qt::white);
-                painter->drawRoundRect(p_.x() ,p_.y(), recW, -recH);
+                painter->drawRoundedRect(p_.x() ,p_.y(), recW, -recH, 25, 25);
                 painter->drawText(p_.x()+5, p_.y()-recH/2+5, label);
                 angle -= pdegree/2;
             }

--- a/Velocity/nightcharts.cpp
+++ b/Velocity/nightcharts.cpp
@@ -19,6 +19,8 @@
  */
 #include "nightcharts.h"
 #include <QGraphicsScene>
+#include <QPainterPath>
+#include <QFontMetrics>
 
 Nightcharts::Nightcharts()//QPainter *painter)
 

--- a/Velocity/nightcharts.cpp
+++ b/Velocity/nightcharts.cpp
@@ -313,7 +313,7 @@ int Nightcharts::draw(QPainter *painter)
             painter->drawRect(cX+pDist+i*(pW + pDist),cY+cH,pW,-cH/100*pieces[i].pPerc-5);
             QString label = QString::number(pieces[i].pPerc)+"%";
             painter->setPen(Qt::SolidLine);
-            painter->drawText(cX+pDist+i*(pW + pDist)+pW/2-painter->fontMetrics().width(label)/2,
+            painter->drawText(cX+pDist+i*(pW + pDist)+pW/2-painter->fontMetrics().horizontalAdvance(label)/2,
                     cY+cH-cH/100*pieces[i].pPerc-painter->fontMetrics().height()/2,label);
         }
         painter->setPen(Qt::SolidLine);
@@ -394,7 +394,7 @@ int Nightcharts::drawLegend(QPainter *painter)
                 }
                 painter->drawLine(p.x(),p.y(),p_.x(),p_.y());
                 QString label = pieces[i].pname + " - " + QString::number(pieces[i].pPerc)+"%";
-                float recW = painter->fontMetrics().width(label)+10;
+                float recW = painter->fontMetrics().horizontalAdvance(label)+10;
                 float recH = painter->fontMetrics().height()+10;
                 p_.setX(p_.x()-recW/2 + recW/2*cos(angle*M_PI/180));
                 p_.setY(p_.y()+recH/2 + recH/2*sin(angle*M_PI/180));

--- a/Velocity/packageviewer.cpp
+++ b/Velocity/packageviewer.cpp
@@ -304,7 +304,7 @@ void PackageViewer::on_btnViewAll_clicked()
 
 void PackageViewer::showSaveImageContextMenu(QPoint point)
 {
-    if (ui->imgTile->pixmap()->isNull())
+    if (ui->imgTile->pixmap().isNull())
         return;
 
     QPoint globalPos = ui->imgTile->mapToGlobal(point);
@@ -323,7 +323,7 @@ void PackageViewer::showSaveImageContextMenu(QPoint point)
         if (imageSavePath == "")
             return;
 
-        ui->imgTile->pixmap()->save(imageSavePath, "PNG");
+        ui->imgTile->pixmap().save(imageSavePath, "PNG");
 
         statusBar->showMessage("Thumbnail image saved successfully", 3000);
     }

--- a/Velocity/partitiondialog.cpp
+++ b/Velocity/partitiondialog.cpp
@@ -36,7 +36,7 @@ void PartitionDialog::on_comboBox_currentIndexChanged(int index)
 
     // draw the chart
     QPixmap chart(391, 221);
-    chart.fill(ui->imgPiechart->palette().background().color());
+    chart.fill(ui->imgPiechart->palette().window().color());
     QPainter painter(&chart);
     Nightcharts pieChart;
     pieChart.setType(Nightcharts::Dpie);

--- a/Velocity/profilecreatorwizard.cpp
+++ b/Velocity/profilecreatorwizard.cpp
@@ -208,7 +208,7 @@ bool ProfileCreatorWizard::verifyGamertag(QString gamertag)
     if (gamertag.length() == 0 || gamertag.length() > 15 || !gamertag.at(0).isLetter())
         return false;
 
-    QChar prevChar = 0;
+    QChar prevChar(0);
     for (int i = 1; i < gamertag.length(); i++)
     {
         if (gamertag.at(i) == ' ' && prevChar == ' ')

--- a/Velocity/profileeditor.cpp
+++ b/Velocity/profileeditor.cpp
@@ -575,13 +575,13 @@ void ProfileEditor::onAssetsDoneDownloading()
         QByteArray baThumb;
         QBuffer buffThumb(&baThumb);
         buffThumb.open(QIODevice::WriteOnly);
-        ui->imgAw->pixmap()->save(&buffThumb, "PNG");
+        ui->imgAw->pixmap().save(&buffThumb, "PNG");
         newAsset.InjectData((BYTE*)baThumb.data(), baThumb.length(), "icon.png");
 
         QByteArray baScaled;
         QBuffer buffScaled(&baScaled);
         buffScaled.open(QIODevice::WriteOnly);
-        QPixmap scaled = ui->imgAw->pixmap()->scaled(QSize(64, 64));
+        QPixmap scaled = ui->imgAw->pixmap().scaled(QSize(64, 64));
         scaled.save(&buffScaled, "PNG");
         newAsset.metaData->thumbnailImage = (BYTE*)baScaled.data();
         newAsset.metaData->thumbnailImageSize = baScaled.length();
@@ -756,7 +756,7 @@ void ProfileEditor::loadGameInfo(int index)
 
 void ProfileEditor::saveImage(QPoint p, QLabel *imgLabel)
 {
-    if (imgLabel->pixmap()->isNull())
+    if (imgLabel->pixmap().isNull())
         return;
 
     QPoint globalPos = imgLabel->mapToGlobal(p);
@@ -775,7 +775,7 @@ void ProfileEditor::saveImage(QPoint p, QLabel *imgLabel)
         if (saveFileName == "")
             return;
 
-        imgLabel->pixmap()->save(saveFileName, "PNG");
+        imgLabel->pixmap().save(saveFileName, "PNG");
         QMessageBox::information(this, "Success", "Successfully saved thumbnail image");
     }
 }
@@ -987,7 +987,7 @@ void ProfileEditor::replyFinishedAwImg(QNetworkReply *aReply)
                 1001).value<struct AvatarAward*>();
 
         // add the avatar image to the gpd if it isn't already there
-        if (ok && !ui->imgAw->pixmap()->isNull())
+        if (ok && !ui->imgAw->pixmap().isNull())
         {
             for (size_t i = 0; i < games.size(); i++)
             {
@@ -1005,7 +1005,7 @@ void ProfileEditor::replyFinishedAwImg(QNetworkReply *aReply)
                         QBuffer buffer(&ba);
                         buffer.open(QIODevice::WriteOnly);
 
-                        ui->imgAw->pixmap()->scaled(64, 64).save(&buffer, "PNG");
+                        ui->imgAw->pixmap().scaled(64, 64).save(&buffer, "PNG");
                         image.image = new BYTE[ba.length()];
                         image.length = ba.length();
                         image.initialLength = ba.length();

--- a/Velocity/profileeditor.cpp
+++ b/Velocity/profileeditor.cpp
@@ -741,8 +741,8 @@ void ProfileEditor::loadGameInfo(int index)
     if (title->lastPlayed == 0)
         ui->lblGameLastPlayed->setText("<span style=\"color:#4f4f4f;\">N/A</span>");
     else
-        ui->lblGameLastPlayed->setText("<span style=\"color:#4f4f4f;\">" + QDateTime::fromTime_t(
-                    title->lastPlayed).toString(Qt::SystemLocaleShortDate) + "</span>");
+        ui->lblGameLastPlayed->setText("<span style=\"color:#4f4f4f;\">" + QDateTime::fromSecsSinceEpoch(
+                    title->lastPlayed).toString(QLocale::system().dateFormat(QLocale::ShortFormat)) + "</span>");
     ui->lblGameAchvs->setText("<span style=\"color:#4f4f4f;\">" + QString::number(
                 title->achievementsUnlocked) + " out of " + QString::number(title->achievementCount) + " unlocked" +
             "</span>");
@@ -831,7 +831,7 @@ void ProfileEditor::loadAchievementInfo(int gameIndex, unsigned int chievIndex)
         ui->dteAchTimestamp->setEnabled(false);
     }
 
-    ui->dteAchTimestamp->setDateTime(QDateTime::fromTime_t(entry.unlockTime).addMSecs(entry.unlockTimeMilliseconds));
+    ui->dteAchTimestamp->setDateTime(QDateTime::fromSecsSinceEpoch(entry.unlockTime).addMSecs(entry.unlockTimeMilliseconds));
 
     // set the thumbnail
     ImageEntry img;
@@ -888,8 +888,8 @@ void ProfileEditor::loadAwardGameInfo(int index)
     if (title->lastPlayed == 0x67D6Ca80)
         ui->lblAwGameLastPlayed->setText("<span style=\"color:#4f4f4f;\">N/A</span>");
     else
-        ui->lblAwGameLastPlayed->setText("<span style=\"color:#4f4f4f;\">" + QDateTime::fromTime_t(
-                    title->lastPlayed).toString(Qt::SystemLocaleShortDate) + "</span>");
+        ui->lblAwGameLastPlayed->setText("<span style=\"color:#4f4f4f;\">" + QDateTime::fromSecsSinceEpoch(
+                    title->lastPlayed).toString(QLocale::system().dateFormat(QLocale::ShortFormat)) + "</span>");
     ui->lblAwGameAwards->setText("<span style=\"color:#4f4f4f;\">" + QString::number(
                 title->avatarAwardsEarned) + " out of " + QString::number(title->avatarAwardCount) + " unlocked" +
             "</span>");
@@ -966,7 +966,7 @@ void ProfileEditor::loadAvatarAwardInfo(int gameIndex, unsigned int awardIndex)
         ui->dteAwTimestamp->setEnabled(false);
     }
 
-    ui->dteAwTimestamp->setDateTime(QDateTime::fromTime_t(award->unlockTime).addMSecs(award->unlockTimeMilliseconds));
+    ui->dteAwTimestamp->setDateTime(QDateTime::fromSecsSinceEpoch(award->unlockTime).addMSecs(award->unlockTimeMilliseconds));
 
     // download the thumbnail
     string tmp = AvatarAwardGpd::GetLargeAwardImageURL(award);
@@ -1199,7 +1199,7 @@ void ProfileEditor::updateAvatarAward(TitleEntry *entry, AvatarAwardGpd *gpd,
         if (award->subcategory == 0)
             award->subcategory = (AssetSubcategory)0xFFFFFFFF;
         award->colorizable = 0;
-        entry->lastPlayed = QDateTime::currentDateTime().toTime_t();
+        entry->lastPlayed = QDateTime::currentDateTime().currentSecsSinceEpoch();
     }
 
     // Write the entry back to the gpd
@@ -1299,7 +1299,7 @@ void ProfileEditor::updateAchievement(TitleEntry *entry, AchievementEntry *chiev
         else if (toSet == StateUnlockedOnline)
         {
             chiev->flags |= (Unlocked | UnlockedOnline | 0x100000);
-            entry->lastPlayed = QDateTime::currentDateTime().toTime_t();
+            entry->lastPlayed = QDateTime::currentDateTime().currentSecsSinceEpoch();
         }
 
         entry->flags |= (SyncAchievement | DownloadAchievementImage);
@@ -1686,15 +1686,15 @@ void ProfileEditor::on_dteAchTimestamp_dateTimeChanged(const QDateTime &date)
                 ui->achievementsList->currentIndex().row());
 
     // make sure the user changed the time
-    if (date.toTime_t() == entry->unlockTime)
+    if (date.currentSecsSinceEpoch() == entry->unlockTime)
         return;
 
     games.at(ui->gamesList->currentIndex().row()).gpd->StartWriting();
 
-    entry->unlockTime = date.toTime_t();
+    entry->unlockTime = date.currentSecsSinceEpoch();
     entry->unlockTimeMilliseconds = date.time().msec();
 
-    ui->dteAchTimestamp->setDateTime(QDateTime::fromTime_t(entry->unlockTime).addMSecs(entry->unlockTimeMilliseconds));
+    ui->dteAchTimestamp->setDateTime(QDateTime::fromSecsSinceEpoch(entry->unlockTime).addMSecs(entry->unlockTimeMilliseconds));
     games.at(ui->gamesList->currentIndex().row()).gpd->WriteAchievementEntry(entry);
     games.at(ui->gamesList->currentIndex().row()).updated = true;
 
@@ -1712,10 +1712,10 @@ void ProfileEditor::on_dteAwTimestamp_dateTimeChanged(const QDateTime &date)
                 ui->avatarAwardsList->currentIndex().row());
 
     // make sure the user changed the time
-    if (date.toTime_t() == entry->unlockTime)
+    if (date.currentSecsSinceEpoch() == entry->unlockTime)
         return;
 
-    entry->unlockTime = date.toTime_t();
+    entry->unlockTime = date.currentSecsSinceEpoch();
     entry->unlockTimeMilliseconds = date.time().msec();
     aaGames.at(ui->aaGamelist->currentIndex().row()).gpd->WriteAvatarAward(entry);
     aaGames.at(ui->aaGamelist->currentIndex().row()).updated = true;

--- a/Velocity/profileeditor.cpp
+++ b/Velocity/profileeditor.cpp
@@ -1634,14 +1634,14 @@ void ProfileEditor::showAllGames()
 {
     // show all the items
     for (int i = 0; i < ui->gamesList->topLevelItemCount(); i++)
-        ui->gamesList->setItemHidden(ui->gamesList->topLevelItem(i), false);
+        ui->gamesList->topLevelItem(i)->setHidden(false);
 }
 
 void ProfileEditor::showAllAwardGames()
 {
     // show all the items
     for (int i = 0; i < ui->aaGamelist->topLevelItemCount(); i++)
-        ui->aaGamelist->setItemHidden(ui->aaGamelist->topLevelItem(i), false);
+        ui->aaGamelist->topLevelItem(i)->setHidden(false);
 }
 
 void ProfileEditor::on_btnAwardShowAll_clicked()
@@ -1730,7 +1730,7 @@ void ProfileEditor::on_txtGameSearch_textChanged(const QString & /*arg1*/)
 
     // hide all the items
     for (int i = 0; i < ui->gamesList->topLevelItemCount(); i++)
-        ui->gamesList->setItemHidden(ui->gamesList->topLevelItem(i), true);
+        ui->gamesList->topLevelItem(i)->setHidden(true);
 
     if (itemsMatched.count() == 0)
     {
@@ -1741,7 +1741,7 @@ void ProfileEditor::on_txtGameSearch_textChanged(const QString & /*arg1*/)
     ui->txtGameSearch->setStyleSheet("");
     // add all the matched ones to the list
     for (int i = 0; i < itemsMatched.count(); i++)
-        ui->gamesList->setItemHidden(itemsMatched.at(i), false);
+        itemsMatched.at(i)->setHidden(false);
 }
 
 void ProfileEditor::on_txtAwardGameSearch_textChanged(const QString & /* arg1 */)
@@ -1751,7 +1751,7 @@ void ProfileEditor::on_txtAwardGameSearch_textChanged(const QString & /* arg1 */
 
     // hide all the items
     for (int i = 0; i < ui->aaGamelist->topLevelItemCount(); i++)
-        ui->aaGamelist->setItemHidden(ui->aaGamelist->topLevelItem(i), true);
+        ui->aaGamelist->topLevelItem(i)->setHidden(true);
 
     if (itemsMatched.count() == 0)
     {
@@ -1762,7 +1762,7 @@ void ProfileEditor::on_txtAwardGameSearch_textChanged(const QString & /* arg1 */
     ui->txtAwardGameSearch->setStyleSheet("");
     // add all the matched ones to the list
     for (int i = 0; i < itemsMatched.count(); i++)
-        ui->aaGamelist->setItemHidden(itemsMatched.at(i), false);
+        itemsMatched.at(i)->setHidden(false);
 }
 
 void ProfileEditor::on_tabWidget_currentChanged(int index)

--- a/Velocity/qthelpers.cpp
+++ b/Velocity/qthelpers.cpp
@@ -330,7 +330,7 @@ void QtHelpers::GetFileIcon(DWORD magic, QString fileName, QIcon &icon, QTreeWid
             icon = QIcon(":/Images/XEXFileIcon.png");
             item.setData(1, Qt::UserRole, "XEX");
             break;
-        case 0x89504E47:    // ‰PNG
+        case 0x89504E47:    // Â‰PNG
             icon = QIcon(":/Images/ImageFileIcon.png");
             item.setData(1, Qt::UserRole, "Image");
             break;

--- a/Velocity/qthelpers.cpp
+++ b/Velocity/qthelpers.cpp
@@ -265,13 +265,13 @@ void QtHelpers::SearchTreeWidget(QTreeWidget *widget, QLineEdit *searchWidget, Q
         QTreeWidgetItem *parent = itemsMatched.at(i)->parent();
         while (parent != NULL)
         {
-            widget->setItemHidden(parent, false);
+            parent->setHidden(false);
             parent->setExpanded(true);
             parent = parent->parent();
         }
 
         // show the item itself
-        widget->setItemHidden(itemsMatched.at(i), false);
+        itemsMatched.at(i)->setHidden(false);
     }
 }
 

--- a/Velocity/qthelpers.h
+++ b/Velocity/qthelpers.h
@@ -18,6 +18,7 @@
 #include <QCheckBox>
 #include <QProgressBar>
 #include <QMdiArea>
+#include <QStandardPaths>
 
 // other
 #include "winnames.h"

--- a/Velocity/themecreationwizard.cpp
+++ b/Velocity/themecreationwizard.cpp
@@ -63,7 +63,7 @@ void ThemeCreationWizard::onFinished(int status)
         QByteArray ba1;
         QBuffer buffer1(&ba1);
         buffer1.open(QIODevice::WriteOnly);
-        ui->imgThumbnail->pixmap()->save(&buffer1, "PNG");
+        ui->imgThumbnail->pixmap().save(&buffer1, "PNG");
         theme->metaData->thumbnailImage = (BYTE*)ba1.data();
         theme->metaData->thumbnailImageSize = ba1.length();
 

--- a/Velocity/titleidfinder.cpp
+++ b/Velocity/titleidfinder.cpp
@@ -17,7 +17,7 @@ void TitleIdFinder::StartSearch()
 void TitleIdFinder::replyFinished(QNetworkReply *reply)
 {
     QString pageSource(reply->readAll());
-    QRegExp exp("66acd000-77fe-1000-9115-d802(.{8})\\?cid=search\"\\>([^<]*)");
+    QRegularExpression exp("66acd000-77fe-1000-9115-d802(.{8})\\?cid=search\"\\>([^<]*)");
 
     QList<TitleData> matches;
 

--- a/Velocity/titleidfinder.cpp
+++ b/Velocity/titleidfinder.cpp
@@ -21,13 +21,12 @@ void TitleIdFinder::replyFinished(QNetworkReply *reply)
 
     QList<TitleData> matches;
 
-    int pos = 0;
-    while ((pos = exp.indexIn(pageSource, pos)) != -1)
-    {
+    auto matchIterator = exp.globalMatch(pageSource);
+    while (matchIterator.hasNext()) {
+        QRegularExpressionMatch match = matchIterator.next();
         TitleData t;
-        t.titleID = exp.cap(1).toULong(0, 16);
-        t.titleName = exp.cap(2);
-        pos += exp.matchedLength();
+        t.titleID = match.captured(1).toULong(0, 16);
+        t.titleName = match.captured(2);
 
         if (t.titleName != "Learn More")
             matches.push_back(t);

--- a/Velocity/titleidfinder.h
+++ b/Velocity/titleidfinder.h
@@ -7,7 +7,7 @@
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
-#include <QRegExp>
+#include <QRegularExpression>
 
 // other
 #include "winnames.h"

--- a/Velocity/titleidfinderdialog.cpp
+++ b/Velocity/titleidfinderdialog.cpp
@@ -39,8 +39,8 @@ void TitleIdFinderDialog::onRequestFinished(QList<TitleData> matches)
     {
         QTreeWidgetItem *item = new QTreeWidgetItem(ui->treeWidget);
 
-        QString newStr = ((QString*)&matches.at(i).titleName)->replace("&#174;", "®").replace("&#39;",
-                "'").replace("&amp;","&").replace("&gt;",">").replace("&lt;","<").replace("â", "").replace("¢", "");
+        QString newStr = ((QString*)&matches.at(i).titleName)->replace("&#174;", "Â®").replace("&#39;",
+                "'").replace("&amp;","&").replace("&gt;",">").replace("&lt;","<").replace("Ã¢", "").replace("Â¢", "");
         item->setText(0, newStr);
         item->setText(1, QString::number(matches.at(i).titleID, 16).toUpper());
 

--- a/Velocity/xdbfdialog.cpp
+++ b/Velocity/xdbfdialog.cpp
@@ -354,7 +354,7 @@ void XdbfDialog::on_treeWidget_doubleClicked(const QModelIndex &index)
                 }
                 case TimeStamp:
                     QMessageBox::about(this, "Setting",
-                            "<html><center><h3>Timestamp Setting</h3><br />" + QDateTime::fromTime_t(
+                            "<html><center><h3>Timestamp Setting</h3><br />" + QDateTime::fromSecsSinceEpoch(
                                 setting.timeStamp).toString() + "</center></html>");
                     break;
                 default:

--- a/Velocity/ytgrdialog.cpp
+++ b/Velocity/ytgrdialog.cpp
@@ -14,7 +14,7 @@ YtgrDialog::YtgrDialog(Ytgr *ytgr, QStatusBar *statusBar, QWidget *parent) :
             QString::number(ytgr->XSignerMinimumVersion.minor) + "." +
             QString::number(ytgr->XSignerMinimumVersion.build) + "." +
             QString::number(ytgr->XSignerMinimumVersion.revision));
-    ui->lblAddedToServer->setText(QDateTime::fromTime_t(ytgr->dateAddedToServer).toString());
+    ui->lblAddedToServer->setText(QDateTime::fromSecsSinceEpoch(ytgr->dateAddedToServer).toString());
     ui->lblContentLength->setText("0x" + QString::number(ytgr->contentLength, 16).toUpper());
     ui->lblValid->setText((ytgr->valid) ? "Yes" : "No");
     ui->txtContentHash->setText(QtHelpers::ByteArrayToString(ytgr->contentHash, 0x14, true));

--- a/XboxInternals/Account/Account.h
+++ b/XboxInternals/Account/Account.h
@@ -9,10 +9,8 @@
 #include "Stfs/StfsConstants.h"
 
 // botan
-#include <botan/botan.h>
-#include <botan/sha160.h>
-#include <botan/hmac.h>
-#include <botan/arc4.h>
+#include <botan/mac.h>
+#include <botan/stream_cipher.h>
 
 #include "XboxInternals_global.h"
 

--- a/XboxInternals/AvatarAsset/Ytgr.cpp
+++ b/XboxInternals/AvatarAsset/Ytgr.cpp
@@ -60,8 +60,7 @@ void Ytgr::Parse()
     // verify the hash
     BYTE block[0x1000];
     BYTE calculatedHash[0x14];
-    Botan::SHA_160 sha1;
-    sha1.clear();
+    const auto sha1 = Botan::HashFunction::create_or_throw("SHA-1");
 
     io->SetPosition(0x130);
     DWORD tempLen = contentLength;
@@ -69,16 +68,16 @@ void Ytgr::Parse()
     while (tempLen >= 0x1000)
     {
         io->ReadBytes(block, 0x1000);
-        sha1.update(block, 0x1000);
+        sha1->update(block, 0x1000);
         tempLen -= 0x1000;
     }
     if (tempLen != 0)
     {
         io->ReadBytes(block, tempLen);
-        sha1.update(block, tempLen);
+        sha1->update(block, tempLen);
     }
 
-    sha1.final(calculatedHash);
+    sha1->final(calculatedHash);
 
     // make sure both the signature and hash are valid
     valid = valid && !memcmp(contentHash, calculatedHash, 0x14);

--- a/XboxInternals/AvatarAsset/Ytgr.h
+++ b/XboxInternals/AvatarAsset/Ytgr.h
@@ -7,8 +7,7 @@
 #include "../Cryptography/XeKeys.h"
 #include "../Gpd/XdbfHelpers.h"
 #include "../Stfs/StfsConstants.h"
-#include <botan/botan.h>
-#include <botan/sha160.h>
+#include <botan/hash.h>
 
 class XBOXINTERNALSSHARED_EXPORT Ytgr
 {

--- a/XboxInternals/Cryptography/XeCrypt.cpp
+++ b/XboxInternals/Cryptography/XeCrypt.cpp
@@ -21,7 +21,7 @@ void XeCrypt::BnQw_SwapDwQwLeBe(BYTE *data, DWORD length)
 bool XeCrypt::Pkcs1Verify(BYTE *pbMessage, DWORD cbMessage, BYTE *pbSignature, DWORD cbSignature,
         UINT64 publicExponent, BYTE *modulus)
 {
-    Botan::RSA_PublicKey pubKey(Botan::BigInt::decode(modulus, cbSignature), publicExponent);
-    Botan::PK_Verifier verifier(pubKey, "EMSA3(SHA-160)");
+    Botan::RSA_PublicKey pubKey(Botan::BigInt(modulus, cbSignature), publicExponent);
+    Botan::PK_Verifier verifier(pubKey, "EMSA3(SHA-1)");
     return verifier.verify_message(pbMessage, cbMessage, pbSignature, cbSignature);
 }

--- a/XboxInternals/Cryptography/XeCrypt.h
+++ b/XboxInternals/Cryptography/XeCrypt.h
@@ -5,13 +5,9 @@
 #include <iostream>
 #include <string.h>
 
-#include <botan/botan.h>
-#include <botan/pubkey.h>
+#include <botan/bigint.h>
 #include <botan/rsa.h>
-#include <botan/emsa.h>
-#include <botan/sha160.h>
-#include <botan/emsa3.h>
-#include <botan/look_pk.h>
+#include <botan/pubkey.h>
 
 #include "XboxInternals_global.h"
 

--- a/XboxInternals/Cryptography/XeKeys.h
+++ b/XboxInternals/Cryptography/XeKeys.h
@@ -5,14 +5,6 @@
 #include "XeCrypt.h"
 #include "IO/FileIO.h"
 
-#include <botan/botan.h>
-#include <botan/pubkey.h>
-#include <botan/rsa.h>
-#include <botan/emsa.h>
-#include <botan/sha160.h>
-#include <botan/emsa3.h>
-#include <botan/look_pk.h>
-
 #include <iostream>
 
 #include "XboxInternals_global.h"

--- a/XboxInternals/Disc/Svod.cpp
+++ b/XboxInternals/Disc/Svod.cpp
@@ -234,20 +234,18 @@ void SVOD::Rehash(void (*progress)(DWORD, DWORD, void*), void *arg)
     rootFile->SetPosition(0x344);
     rootFile->ReadBytes(buff, dataLen);
 
-    Botan::SHA_160 sha1;
-    sha1.clear();
-    sha1.update(buff, dataLen);
-    sha1.final(metadata->headerHash);
+    const auto sha1 = Botan::HashFunction::create_or_throw("SHA-1");
+    sha1->update(buff, dataLen);
+    sha1->final(metadata->headerHash);
 
     metadata->WriteMetaData();
 }
 
 void SVOD::HashBlock(BYTE *block, BYTE *outHash)
 {
-    Botan::SHA_160 sha1;
-    sha1.clear();
-    sha1.update(block, 0x1000);
-    sha1.final(outHash);
+    const auto sha1 = Botan::HashFunction::create_or_throw("SHA-1");
+    sha1->update(block, 0x1000);
+    sha1->final(outHash);
 }
 
 void SVOD::WriteFileEntry(GdfxFileEntry *entry)

--- a/XboxInternals/Disc/Svod.h
+++ b/XboxInternals/Disc/Svod.h
@@ -9,8 +9,7 @@
 #include <vector>
 #include "IO/SvodIO.h"
 #include <algorithm>
-#include "botan/botan.h"
-#include "botan/sha160.h"
+#include <botan/hash.h>
 
 #include "XboxInternals_global.h"
 

--- a/XboxInternals/Fatx/FatxDrive.cpp
+++ b/XboxInternals/Fatx/FatxDrive.cpp
@@ -362,8 +362,8 @@ void FatxDrive::InjectFile(FatxFileEntry *parent, std::string name, std::string 
 #if __WIN32
     // TODO: put windows file length code here
 #else
-    struct stat64 fileInfo;
-    if (stat64(filePath.c_str(), &fileInfo) != 0)
+    struct stat fileInfo;
+    if (stat(filePath.c_str(), &fileInfo) != 0)
         throw std::string("FATX: Error opening the file.\n");
     fileLength = fileInfo.st_size;
 #endif

--- a/XboxInternals/IO/BaseIO.h
+++ b/XboxInternals/IO/BaseIO.h
@@ -29,7 +29,7 @@ public:
     void SwapEndian();
 
     // seek to a position in a file
-    virtual void SetPosition(UINT64 position, std::ios_base::seek_dir dir = std::ios_base::beg) = 0;
+    virtual void SetPosition(UINT64 position, std::ios_base::seekdir dir = std::ios_base::beg) = 0;
 
     // get current address in the file
     virtual UINT64 GetPosition() = 0;

--- a/XboxInternals/IO/DeviceIO.cpp
+++ b/XboxInternals/IO/DeviceIO.cpp
@@ -325,7 +325,7 @@ UINT64 DeviceIO::Length()
     return length;
 }
 
-void DeviceIO::SetPosition(UINT64 address, std::ios_base::seek_dir dir)
+void DeviceIO::SetPosition(UINT64 address, std::ios_base::seekdir dir)
 {
     if (dir != std::ios_base::beg)
         throw std::string("DeviceIO: Unsupported seek direction\n");

--- a/XboxInternals/IO/DeviceIO.h
+++ b/XboxInternals/IO/DeviceIO.h
@@ -25,7 +25,7 @@ public:
 
     void WriteBytes(BYTE *buffer, DWORD len);
 
-    void SetPosition(UINT64 address, std::ios_base::seek_dir dir = std::ios_base::beg);
+    void SetPosition(UINT64 address, std::ios_base::seekdir dir = std::ios_base::beg);
 
     UINT64 GetPosition();
 

--- a/XboxInternals/IO/FatxIO.cpp
+++ b/XboxInternals/IO/FatxIO.cpp
@@ -11,7 +11,7 @@ FatxIO::~FatxIO()
 {
 }
 
-void FatxIO::SetPosition(UINT64 position, std::ios_base::seek_dir dir)
+void FatxIO::SetPosition(UINT64 position, std::ios_base::seekdir dir)
 {
     if (dir == std::ios_base::cur)
         position += pos;

--- a/XboxInternals/IO/FatxIO.h
+++ b/XboxInternals/IO/FatxIO.h
@@ -29,7 +29,7 @@ public:
     FatxFileEntry *GetFatxFileEntry();
 
     // set the position
-    void SetPosition(UINT64 position, std::ios_base::seek_dir dir = std::ios_base::beg);
+    void SetPosition(UINT64 position, std::ios_base::seekdir dir = std::ios_base::beg);
 
     // get the current position
     UINT64 GetPosition();

--- a/XboxInternals/IO/FileIO.cpp
+++ b/XboxInternals/IO/FileIO.cpp
@@ -23,7 +23,7 @@ FileIO::FileIO(string path, bool truncate) :
     fstr->seekp(0);
 }
 
-void FileIO::SetPosition(UINT64 pos, ios_base::seek_dir dir)
+void FileIO::SetPosition(UINT64 pos, ios_base::seekdir dir)
 {
     fstr->seekp(pos, static_cast<std::ios_base::seekdir>(dir));
 }

--- a/XboxInternals/IO/FileIO.h
+++ b/XboxInternals/IO/FileIO.h
@@ -17,7 +17,7 @@ class XBOXINTERNALSSHARED_EXPORT FileIO : public BaseIO
 {
 public:
     FileIO(string path, bool truncate = false);
-    void SetPosition(UINT64 pos, ios_base::seek_dir dir = ios_base::beg);
+    void SetPosition(UINT64 pos, ios_base::seekdir dir = ios_base::beg);
     UINT64 GetPosition();
     UINT64 Length();
 

--- a/XboxInternals/IO/MemoryIO.cpp
+++ b/XboxInternals/IO/MemoryIO.cpp
@@ -11,7 +11,7 @@ MemoryIO::~MemoryIO()
 
 }
 
-void MemoryIO::SetPosition(UINT64 pos, std::ios_base::seek_dir dir)
+void MemoryIO::SetPosition(UINT64 pos, std::ios_base::seekdir dir)
 {
     DWORD newPos;
     switch (dir)

--- a/XboxInternals/IO/MemoryIO.h
+++ b/XboxInternals/IO/MemoryIO.h
@@ -11,7 +11,7 @@ public:
     MemoryIO(BYTE *data, size_t length);
     virtual ~MemoryIO();
 
-    void SetPosition(UINT64 pos, std::ios_base::seek_dir dir = std::ios_base::beg);
+    void SetPosition(UINT64 pos, std::ios_base::seekdir dir = std::ios_base::beg);
     UINT64 GetPosition();
     UINT64 Length();
 

--- a/XboxInternals/IO/MultiFileIO.cpp
+++ b/XboxInternals/IO/MultiFileIO.cpp
@@ -21,7 +21,7 @@ MultiFileIO::~MultiFileIO()
     Close();
 }
 
-void MultiFileIO::SetPosition(UINT64 position, std::ios_base::seek_dir dir)
+void MultiFileIO::SetPosition(UINT64 position, std::ios_base::seekdir dir)
 {
     if (dir == std::ios_base::end)
         throw std::string("MultiFileIO: Unsupported seek dir.");

--- a/XboxInternals/IO/MultiFileIO.h
+++ b/XboxInternals/IO/MultiFileIO.h
@@ -15,7 +15,7 @@ public:
     virtual ~MultiFileIO();
 
     // seek to a position in a file
-    void SetPosition(UINT64 position, std::ios_base::seek_dir dir = std::ios_base::beg);
+    void SetPosition(UINT64 position, std::ios_base::seekdir dir = std::ios_base::beg);
 
     // get current address in the file
     UINT64 GetPosition();

--- a/XboxInternals/IO/SvodIO.cpp
+++ b/XboxInternals/IO/SvodIO.cpp
@@ -30,7 +30,7 @@ void SvodIO::SectorToAddress(DWORD sector, DWORD *addressInDataFile, DWORD *data
             trueSector != 0) ? 0 : 1)) * 0x1000;
 }
 
-void SvodIO::SetPosition(UINT64 address, ios_base::seek_dir dir)
+void SvodIO::SetPosition(UINT64 address, ios_base::seekdir dir)
 {
     if (dir != std::ios_base::beg)
         throw std::string("SvodIO: Unsupported seek direction\n");

--- a/XboxInternals/IO/SvodIO.h
+++ b/XboxInternals/IO/SvodIO.h
@@ -21,7 +21,7 @@ public:
 
     void OverWriteFile(string inPath, void (*progress)(void*, DWORD, DWORD) = NULL, void *arg = NULL);
 
-    void SetPosition(UINT64 address, std::ios_base::seek_dir dir = std::ios_base::beg);
+    void SetPosition(UINT64 address, std::ios_base::seekdir dir = std::ios_base::beg);
 
     UINT64 GetPosition();
 

--- a/XboxInternals/IO/SvodMultiFileIO.cpp
+++ b/XboxInternals/IO/SvodMultiFileIO.cpp
@@ -148,7 +148,7 @@ DWORD SvodMultiFileIO::FileCount()
     return files.size();
 }
 
-void SvodMultiFileIO::SetPosition(UINT64 position, ios_base::seek_dir dir)
+void SvodMultiFileIO::SetPosition(UINT64 position, ios_base::seekdir dir)
 {
     throw string("MultiFileIO: Unused function has been called.\n");
 }

--- a/XboxInternals/IO/SvodMultiFileIO.h
+++ b/XboxInternals/IO/SvodMultiFileIO.h
@@ -42,7 +42,7 @@ public:
     DWORD CurrentFileLength();
 
     // unused
-    void SetPosition(UINT64 position, std::ios_base::seek_dir dir = std::ios_base::beg);
+    void SetPosition(UINT64 position, std::ios_base::seekdir dir = std::ios_base::beg);
     UINT64 GetPosition();
 
 private:

--- a/XboxInternals/Stfs/StfsPackage.cpp
+++ b/XboxInternals/Stfs/StfsPackage.cpp
@@ -1007,12 +1007,11 @@ void StfsPackage::Rehash()
     io->ReadBytes(buffer, headerSize);
 
     // hash the header
-    Botan::SHA_160 sha1;
-    sha1.update(buffer, headerSize);
-    sha1.final(metaData->headerHash);
+    const auto sha1 = Botan::HashFunction::create_or_throw("SHA-1");
+    sha1->update(buffer, headerSize);
+    sha1->final(metaData->headerHash);
 
     delete[] buffer;
-    sha1.clear();
 
     metaData->WriteMetaData();
 }
@@ -1143,10 +1142,9 @@ void StfsPackage::SetBlockStatus(DWORD blockNum, BlockStatusLevelZero status)
 void StfsPackage::HashBlock(BYTE *block, BYTE *outBuffer)
 {
     // hash the block
-    Botan::SHA_160 sha1;
-    sha1.clear();
-    sha1.update(block, 0x1000);
-    sha1.final(outBuffer);
+    const auto sha1 = Botan::HashFunction::create_or_throw("SHA-1");
+    sha1->update(block, 0x1000);
+    sha1->final(outBuffer);
 }
 
 void StfsPackage::BuildTableInMemory(HashTable *table, BYTE *outBuffer)

--- a/XboxInternals/Stfs/StfsPackage.h
+++ b/XboxInternals/Stfs/StfsPackage.h
@@ -10,13 +10,7 @@
 #include "IO/FileIO.h"
 #include "XContentHeader.h"
 
-#include <botan/botan.h>
-#include <botan/pubkey.h>
-#include <botan/rsa.h>
-#include <botan/emsa.h>
-#include <botan/sha160.h>
-#include <botan/emsa3.h>
-#include <botan/look_pk.h>
+#include <botan/hash.h>
 
 #include "XboxInternals_global.h"
 

--- a/XboxInternals/Stfs/XContentHeader.h
+++ b/XboxInternals/Stfs/XContentHeader.h
@@ -11,13 +11,11 @@
 
 #include <iostream>
 
-#include <botan/botan.h>
-#include <botan/pubkey.h>
+#include <botan/hash.h>
+#include <botan/bigint.h>
+#include <botan/auto_rng.h>
 #include <botan/rsa.h>
-#include <botan/emsa.h>
-#include <botan/sha160.h>
-#include <botan/emsa3.h>
-#include <botan/look_pk.h>
+#include <botan/pubkey.h>
 
 #include "XboxInternals_global.h"
 

--- a/XboxInternals/XboxInternals.pro
+++ b/XboxInternals/XboxInternals.pro
@@ -20,17 +20,17 @@ QMAKE_CXXFLAGS = -O3
 # linking against botan (and adding to include path)
 win32 {
     include(Stfs/Botan.pri)
-    LIBS += C:/botan/libbotan-1.10.a
-    PRE_TARGETDEPS += C:/botan/libbotan-1.10.a
+    LIBS += C:/botan/libbotan-3.a
+    PRE_TARGETDEPS += C:/botan/libbotan-3.a
     INCLUDEPATH += C:/botan/include
 }
 macx {
     INCLUDEPATH += /opt/homebrew/include/botan-3
     LIBS += /opt/homebrew/lib/libbotan-3.a
 }
-unix {
-    INCLUDEPATH += /usr/include/botan-1.10
-    LIBS += /usr/lib/libbotan-1.10.so.0
+else:unix {
+    INCLUDEPATH += /usr/include/botan-3
+    LIBS += /usr/lib/libbotan-3.so.0
 }
 
 SOURCES += \

--- a/XboxInternals/XboxInternals.pro
+++ b/XboxInternals/XboxInternals.pro
@@ -23,8 +23,8 @@ win32 {
     INCLUDEPATH += C:/botan/include
 }
 macx {
-    INCLUDEPATH += /usr/local/include/botan-1.10
-    LIBS += /usr/local/lib/libbotan-1.10.a
+    INCLUDEPATH += /opt/homebrew/include/botan-3
+    LIBS += /opt/homebrew/lib/libbotan-3.a
 }
 unix {
     INCLUDEPATH += /usr/include/botan-1.10

--- a/XboxInternals/XboxInternals.pro
+++ b/XboxInternals/XboxInternals.pro
@@ -12,6 +12,8 @@ DEFINES += XBOXINTERNALS_LIBRARY
 
 unix:CONFIG += staticlib app_bundle
 
+CONFIG += c++20
+
 # flags (lets step it up a notch)
 QMAKE_CXXFLAGS = -O3
 


### PR DESCRIPTION
- **fix: switch to qmake**
- **fix: seek_dir -> seekdir**
- **fix: botan 3 include/lib locations**
- **fix: ensure c++20 std**
- **fix: migrate to botan-3**
- **fix: ensure c++20 std**
- **fix: remove softkeys from mainwindow.ui**
- **fix: case insensitive issue on top Makefile**
- **fix: remove unnecessary botan initialization**
- **fix: add .qmake.stash to .gitignore**
- **fix: pixmap is no longer a pointer**
- **fix: QRegExp to QRegularExpression**
- **fix: switch to UTF-8 encoding**
- **fix: update QDate methods**
- **fix: setItemHidden -> setHidden**
- **fix: add include for QStandardPaths**
- **fix: implicit QChar assignment from int**
- **fix: QNetworkInformation reachability**
- **fix: QRegularExpression new API**
- **fix: use std::sort instead of qSort**
- **fix: QByteArray and QString interactions**
- **fix: QString sprintf deprecation**
- **fix: rename of QPalette::background() -> window()**
- **fix: update QDate methods (tbs)**
- **fix: missing imports**
- **fix: QFontMetrics::width -> horizontalAdvance**
- **fix: QPainter::drawRoundRect -> drawRoundedRect**
- **fix: ensure unix botan libs not used on mac**
- **fix: init QNetworkInformation to avoid crash**
- **chore: add vscode config files**
